### PR TITLE
PRO-3340 : Fixed bug with IHT values being incorrect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,7 @@ dependencies {
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
   testCompile group: 'org.pdfbox', name: 'com.springsource.org.pdfbox', version: '0.7.3'
   testCompile group: 'org.springframework.security', name: 'spring-security-test', version: '4.2.5.RELEASE'
+  testCompile group: 'com.mitchellbosecke', name: 'pebble', version: '2.4.0'
 
   testSmokeCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
   testSmokeCompile sourceSets.main.runtimeClasspath

--- a/src/main/java/uk/gov/hmcts/probate/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/config/ApplicationConfiguration.java
@@ -1,9 +1,15 @@
 package uk.gov.hmcts.probate.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.probate.model.ccd.raw.BigDecimalSerializer;
+
+import java.math.BigDecimal;
 
 @Configuration
 public class ApplicationConfiguration {
@@ -28,4 +34,12 @@ public class ApplicationConfiguration {
         return new RestTemplate();
     }
 
+    @Primary
+    @Bean
+    public ObjectMapper objectMapper(ObjectMapper objectMapper) {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(BigDecimal.class, new BigDecimalSerializer());
+        objectMapper.registerModule(module);
+        return objectMapper;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/InheritanceTax.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/InheritanceTax.java
@@ -11,10 +11,10 @@ import java.math.BigDecimal;
 public class InheritanceTax implements Serializable {
 
     private final String formName;
-    private final Float netValue;
-    private final Float grossValue;
+    private final BigDecimal netValue;
+    private final BigDecimal grossValue;
 
     public BigDecimal getNetValueInPounds() {
-        return BigDecimal.valueOf(netValue).divide(BigDecimal.valueOf(100), 2, BigDecimal.ROUND_HALF_UP);
+        return netValue.divide(BigDecimal.valueOf(100), 2, BigDecimal.ROUND_HALF_UP);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializer.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializer.java
@@ -11,6 +11,6 @@ public class BigDecimalNumberSerializer extends JsonSerializer<BigDecimal> {
 
     @Override
     public void serialize(BigDecimal value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
-        jsonGenerator.writeNumber(value);
+        jsonGenerator.writeNumber(value.setScale(2));
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializer.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializer.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.probate.model.ccd.raw;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class BigDecimalNumberSerializer extends JsonSerializer<BigDecimal> {
+
+    @Override
+    public void serialize(BigDecimal value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        jsonGenerator.writeNumber(value);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalSerializer.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalSerializer.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.probate.model.ccd.raw;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class BigDecimalSerializer extends JsonSerializer<BigDecimal> {
+
+    @Override
+    public void serialize(BigDecimal value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
+        jsonGenerator.writeString(value.toString());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -90,11 +90,11 @@ public class CaseData {
 
     @NotNull(groups = {ApplicationUpdatedGroup.class}, message = "{ihtNetIsNull}")
     @DecimalMin(groups = {ApplicationUpdatedGroup.class}, value = "0.0", message = "{ihtNetNegative}")
-    private final Float ihtNetValue;
+    private final BigDecimal ihtNetValue;
 
     @NotNull(groups = {ApplicationUpdatedGroup.class}, message = "{ihtGrossIsNull}")
     @DecimalMin(groups = {ApplicationUpdatedGroup.class}, value = "0.0", message = "{ihtGrossNegative}")
-    private final Float ihtGrossValue;
+    private final BigDecimal ihtGrossValue;
 
     @NotBlank(groups = {ApplicationUpdatedGroup.class}, message = "{primaryApplicantForenamesIsNull}")
     private final String primaryApplicantForenames;

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.CCDDocument;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.StopReasons;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
@@ -37,8 +38,8 @@ public class ResponseCaseData {
     private final String willAccessOriginal;
     private final String willHasCodicils;
     private final String willNumberOfCodicils;
-    private final String ihtNetValue;
-    private final String ihtGrossValue;
+    private final BigDecimal ihtNetValue;
+    private final BigDecimal ihtGrossValue;
     private final String deceasedDomicileInEngWales;
     private final String extraCopiesOfGrant;
     private final String outsideUKGrantCopies;

--- a/src/main/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementService.java
@@ -2,14 +2,17 @@ package uk.gov.hmcts.probate.service.template.pdf;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.Data;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.probate.config.PDFServiceConfiguration;
 import uk.gov.hmcts.probate.exception.BadRequestException;
 import uk.gov.hmcts.probate.exception.ConnectionException;
+import uk.gov.hmcts.probate.model.ccd.raw.BigDecimalNumberSerializer;
 import uk.gov.hmcts.probate.model.ccd.raw.CCDDocument;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CallbackRequest;
 import uk.gov.hmcts.probate.model.evidencemanagement.EvidenceManagementFile;
@@ -18,20 +21,32 @@ import uk.gov.hmcts.probate.model.template.PDFServiceTemplate;
 import uk.gov.hmcts.probate.service.evidencemanagement.upload.UploadService;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
-@Data
 @Service
 public class PDFManagementService {
-    private final PDFServiceConfiguration pdfServiceConfiguration;
+
     private final PDFGeneratorService pdfGeneratorService;
     private final UploadService uploadService;
-    private final ObjectMapper objectMapper;
-
+    private final ObjectMapper pdfServiceObjectMapper;
+    private final PDFServiceConfiguration pdfServiceConfiguration;
     private static final Logger log = LoggerFactory.getLogger(PDFManagementService.class);
+
+    @Autowired
+    public PDFManagementService(PDFServiceConfiguration pdfServiceConfiguration, PDFGeneratorService pdfGeneratorService,
+                                UploadService uploadService, ObjectMapper objectMapper) {
+        this.pdfServiceConfiguration = pdfServiceConfiguration;
+        this.pdfGeneratorService = pdfGeneratorService;
+        this.uploadService = uploadService;
+        this.pdfServiceObjectMapper = objectMapper.copy();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(BigDecimal.class, new BigDecimalNumberSerializer());
+        this.pdfServiceObjectMapper.registerModule(module);
+    }
 
     public CCDDocument generateAndUpload(CallbackRequest callbackRequest, PDFServiceTemplate pdfServiceTemplate) {
         try {
-            String json = objectMapper.writeValueAsString(callbackRequest);
+            String json = pdfServiceObjectMapper.writeValueAsString(callbackRequest);
             EvidenceManagementFileUpload fileUpload = pdfGeneratorService.generatePdf(pdfServiceTemplate, json);
             EvidenceManagementFile store = uploadService.store(fileUpload);
             return CCDDocument.builder()

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -141,8 +141,8 @@ public class CallbackResponseTransformer {
 
                 .solsSOTNeedToUpdate(caseData.getSolsSOTNeedToUpdate())
 
-                .ihtGrossValue(transformToString(caseData.getIhtGrossValue()))
-                .ihtNetValue(transformToString(caseData.getIhtNetValue()))
+                .ihtGrossValue(caseData.getIhtGrossValue())
+                .ihtNetValue(caseData.getIhtNetValue())
                 .deceasedDomicileInEngWales(caseData.getDeceasedDomicileInEngWales())
 
                 .solsPaymentMethods(caseData.getSolsPaymentMethods())
@@ -200,11 +200,5 @@ public class CallbackResponseTransformer {
                 .map(String::valueOf)
                 .orElse(null);
     }
-
-    private String transformToString(Float value) {
-        return Optional.ofNullable(value)
-                .map(Float::intValue)
-                .map(String::valueOf)
-                .orElse(null);
-    }
+    
 }

--- a/src/main/java/uk/gov/hmcts/probate/validator/IHTValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/IHTValidationRule.java
@@ -30,7 +30,7 @@ class IHTValidationRule implements SolAddDeceasedEstateDetailsValidationRule {
                 .map(iht -> {
                     List<String> codes = new ArrayList<>();
 
-                    if (iht.getNetValue() > iht.getGrossValue()) {
+                    if (iht.getNetValue().compareTo(iht.getGrossValue()) > 0) {
                         codes.add(IHT_NET_GREATER_THAN_GROSS);
                     }
 

--- a/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
@@ -149,16 +149,18 @@ public class BusinessValidationControllerTest {
 
     @Test
     public void shouldValidateWithSolicitorIHTFormIsNullError() throws Exception {
-        //caseDataBuilder.solsIHTFormId(null);
+        caseDataBuilder.solsIHTFormId(null);
         CaseDetails caseDetails = new CaseDetails(caseDataBuilder.build(), LAST_MODIFIED, ID);
         CallbackRequest callbackRequest = new CallbackRequest(caseDetails);
 
         String json = OBJECT_MAPPER.writeValueAsString(callbackRequest);
-        String contentAsString = mockMvc.perform(post(CASE_VALIDATE_URL).content(json).contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andReturn().getResponse().getContentAsString();
-
-
-        Assert.assertTrue(true);
+        mockMvc.perform(post(CASE_VALIDATE_URL).content(json).contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.fieldErrors[0].param").value("callbackRequest"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("caseDetails.data.solsIHTFormId"))
+                .andExpect(jsonPath("$.fieldErrors[0].code").value("NotBlank"))
+                .andExpect(jsonPath("$.fieldErrors[0].message").value("Solicitor IHT Form cannot be empty"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.probate.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.request.CallbackRequest;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData.CaseDataBuilder;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -51,8 +53,8 @@ public class BusinessValidationControllerTest {
     private static final BigDecimal FEE_FOR_UK_COPIES = BigDecimal.TEN;
     private static final BigDecimal FEE_FOR_NON_UK_COPIES = BigDecimal.TEN;
     private static final BigDecimal TOTAL_FEE = BigDecimal.TEN;
-    private static final Float NET = 900f;
-    private static final Float GROSS = 1000f;
+    private static final BigDecimal NET = new BigDecimal("77777777");
+    private static final BigDecimal GROSS = new BigDecimal("999999999");
     private static final Long EXTRA_UK = 1L;
     private static final Long EXTRA_OUTSIDE_UK = 2L;
     private static final String DEC_ADD_LINE1 = "DecLine1";
@@ -82,6 +84,9 @@ public class BusinessValidationControllerTest {
 
     @MockBean
     private AppInsights appInsights;
+
+    @MockBean
+    private PDFManagementService pdfManagementService;
 
     @Before
     public void setup() {
@@ -144,18 +149,16 @@ public class BusinessValidationControllerTest {
 
     @Test
     public void shouldValidateWithSolicitorIHTFormIsNullError() throws Exception {
-        caseDataBuilder.solsIHTFormId(null);
+        //caseDataBuilder.solsIHTFormId(null);
         CaseDetails caseDetails = new CaseDetails(caseDataBuilder.build(), LAST_MODIFIED, ID);
         CallbackRequest callbackRequest = new CallbackRequest(caseDetails);
 
         String json = OBJECT_MAPPER.writeValueAsString(callbackRequest);
-        mockMvc.perform(post(CASE_VALIDATE_URL).content(json).contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.fieldErrors[0].param").value("callbackRequest"))
-                .andExpect(jsonPath("$.fieldErrors[0].field").value("caseDetails.data.solsIHTFormId"))
-                .andExpect(jsonPath("$.fieldErrors[0].code").value("NotBlank"))
-                .andExpect(jsonPath("$.fieldErrors[0].message").value("Solicitor IHT Form cannot be empty"));
+        String contentAsString = mockMvc.perform(post(CASE_VALIDATE_URL).content(json).contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andReturn().getResponse().getContentAsString();
+
+
+        Assert.assertTrue(true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/controller/NextStepsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/NextStepsControllerTest.java
@@ -47,8 +47,8 @@ public class NextStepsControllerTest {
     private static final String PAYMENT_METHOD = "Cheque";
     private static final String WILL_HAS_CODICLIS = "Yes";
     private static final String NUMBER_OF_CODICLIS = "1";
-    private static final Float NET = 1000f;
-    private static final Float GROSS = 900f;
+    private static final BigDecimal NET = BigDecimal.valueOf(1000f);
+    private static final BigDecimal GROSS = BigDecimal.valueOf(900f);
     private static final Long EXTRA_UK = 1L;
     private static final Long EXTRA_OUTSIDE_UK = 2L;
     private static final String DECEASED_ADDRESS_L1 = "DECL1";

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/InheritanceTaxTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/InheritanceTaxTest.java
@@ -14,7 +14,7 @@ public class InheritanceTaxTest {
     public void shouldGetNetValueInPounds() {
 
         InheritanceTax inheritanceTax = InheritanceTax.builder().formName("FORM_NAME")
-                .grossValue(1000F).netValue(800F).build();
+                .grossValue(BigDecimal.valueOf(1000F)).netValue(BigDecimal.valueOf(800F)).build();
 
         assertThat(inheritanceTax.getNetValueInPounds(), comparesEqualTo(new BigDecimal(8.00)));
     }

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
@@ -22,8 +22,8 @@ public class BigDecimalNumberSerializerTest {
         Writer jsonWriter = new StringWriter();
         JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
         SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
-        new BigDecimalNumberSerializer().serialize(new BigDecimal("90000"), jsonGenerator, serializerProvider);
+        new BigDecimalNumberSerializer().serialize(new BigDecimal("90000.00"), jsonGenerator, serializerProvider);
         jsonGenerator.flush();
-        assertThat(jsonWriter.toString(), is(equalTo("90000")));
+        assertThat(jsonWriter.toString(), is(equalTo("90000.00")));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
@@ -22,8 +22,8 @@ public class BigDecimalNumberSerializerTest {
         Writer jsonWriter = new StringWriter();
         JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
         SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
-        new BigDecimalNumberSerializer().serialize(new BigDecimal("90000.00"), jsonGenerator, serializerProvider);;
+        new BigDecimalNumberSerializer().serialize(new BigDecimal("90000"), jsonGenerator, serializerProvider);
         jsonGenerator.flush();
-        assertThat(jsonWriter.toString(), is(equalTo("90000.00")));
+        assertThat(jsonWriter.toString(), is(equalTo("90000")));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalNumberSerializerTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.probate.model.ccd.raw;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BigDecimalNumberSerializerTest {
+
+    @Test
+    public void shouldSerialize() throws IOException {
+        Writer jsonWriter = new StringWriter();
+        JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
+        SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
+        new BigDecimalNumberSerializer().serialize(new BigDecimal("90000.00"), jsonGenerator, serializerProvider);;
+        jsonGenerator.flush();
+        assertThat(jsonWriter.toString(), is(equalTo("90000.00")));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/BigDecimalSerializerTest.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.probate.model.ccd.raw;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BigDecimalSerializerTest {
+
+    @Test
+    public void shouldSerialize() throws IOException {
+        Writer jsonWriter = new StringWriter();
+        JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
+        SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
+        new BigDecimalSerializer().serialize(new BigDecimal("90000.00"), jsonGenerator, serializerProvider);;
+        jsonGenerator.flush();
+        assertThat(jsonWriter.toString(), is(equalTo("\"90000.00\"")));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
@@ -50,8 +50,8 @@ public class ConfirmationResponseServiceFeatureTest {
     private static final BigDecimal TOTAL_FEE = BigDecimal.TEN;
     private static final BigDecimal FEE_UK = new BigDecimal(100);
     private static final BigDecimal FEE_NON_UK = new BigDecimal(200);
-    private static final Float NET = 900f;
-    private static final Float GROSS = 1000f;
+    private static final BigDecimal NET = BigDecimal.valueOf(900f);
+    private static final BigDecimal GROSS = BigDecimal.valueOf(1000f);
     private static final Long EXTRA_UK = 1L;
     private static final Long EXTRA_OUTSIDE_UK = 2L;
     private static final String PAYMENT_REFERENCE = "XXXXX123456";

--- a/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementServiceTest.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.hateoas.Link;
 import uk.gov.hmcts.probate.config.PDFServiceConfiguration;
 import uk.gov.hmcts.probate.exception.BadRequestException;
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.template.PDFServiceTemplate.LEGAL_STATEMENT;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PDFManagementServiceTest {
 
     @Mock
@@ -47,7 +48,6 @@ public class PDFManagementServiceTest {
     @Mock
     private JsonProcessingException jsonProcessingException;
 
-    @InjectMocks
     private PDFManagementService underTest;
 
     @Mock
@@ -55,7 +55,9 @@ public class PDFManagementServiceTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        when(objectMapperMock.copy()).thenReturn(objectMapperMock);
+        underTest = new PDFManagementService(pdfServiceConfigurationMock, pdfGeneratorServiceMock, uploadServiceMock,
+                objectMapperMock);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PdfServiceHtmlTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PdfServiceHtmlTemplateTest.java
@@ -50,8 +50,8 @@ public class PdfServiceHtmlTemplateTest {
     private static final BigDecimal FEE_FOR_UK_COPIES = BigDecimal.TEN;
     private static final BigDecimal FEE_FOR_NON_UK_COPIES = BigDecimal.TEN;
     private static final BigDecimal TOTAL_FEE = BigDecimal.TEN;
-    private static final BigDecimal NET = new BigDecimal("800000");
-    private static final BigDecimal GROSS = new BigDecimal("999999999");
+    private static final BigDecimal NET = new BigDecimal("100001");
+    private static final BigDecimal GROSS = new BigDecimal("9000043");
     private static final Long EXTRA_UK = 1L;
     private static final Long EXTRA_OUTSIDE_UK = 2L;
     private static final String DEC_ADD_LINE1 = "DecLine1";
@@ -128,7 +128,7 @@ public class PdfServiceHtmlTemplateTest {
         module.addSerializer(BigDecimal.class, new BigDecimalNumberSerializer());
         otherObjectMapper.registerModule(module);
 
-        jsonData = objectMapper.writeValueAsString(callbackRequest);
+        jsonData = otherObjectMapper.writeValueAsString(callbackRequest);
     }
 
     @Ignore

--- a/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PdfServiceHtmlTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PdfServiceHtmlTemplateTest.java
@@ -1,0 +1,150 @@
+package uk.gov.hmcts.probate.service.template.pdf;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.probate.model.ccd.raw.BigDecimalNumberSerializer;
+import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
+import uk.gov.hmcts.probate.model.ccd.raw.request.CallbackRequest;
+import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
+import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Map;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+public class PdfServiceHtmlTemplateTest {
+
+    private static final LocalDate DOB = LocalDate.of(1990, 4, 4);
+    private static final LocalDate DOD = LocalDate.of(2017, 4, 4);
+    private static final Long ID = 1L;
+    private static final String[] LAST_MODIFIED = {"2018", "1", "1", "0", "0", "0", "0"};
+    private static final String FORENAME = "Andy";
+    private static final String SURNAME = "Michael";
+    private static final String SOLICITOR_APP_REFERENCE = "Reference";
+    private static final String SOLICITOR_FIRM_NAME = "Legal Service Ltd";
+    private static final String SOLICITOR_FIRM_POSTCODE = "SW1E 6EA";
+    private static final String IHT_FORM = "IHT207";
+    private static final String SOLICITOR_NAME = "Peter Crouch";
+    private static final String SOLICITOR_JOB_TITLE = "Lawyer";
+    private static final String PAYMENT_METHOD = "Cheque";
+    private static final String WILL_HAS_CODICILS = "Yes";
+    private static final String NUMBER_OF_CODICILS = "1";
+    private static final BigDecimal APPLICATION_FEE = BigDecimal.TEN;
+    private static final BigDecimal FEE_FOR_UK_COPIES = BigDecimal.TEN;
+    private static final BigDecimal FEE_FOR_NON_UK_COPIES = BigDecimal.TEN;
+    private static final BigDecimal TOTAL_FEE = BigDecimal.TEN;
+    private static final BigDecimal NET = new BigDecimal("800000");
+    private static final BigDecimal GROSS = new BigDecimal("999999999");
+    private static final Long EXTRA_UK = 1L;
+    private static final Long EXTRA_OUTSIDE_UK = 2L;
+    private static final String DEC_ADD_LINE1 = "DecLine1";
+    private static final String DEC_ADD_PC = "DecPC";
+    private static final SolsAddress DECEASED_ADDRESS = SolsAddress.builder().addressLine1(DEC_ADD_LINE1)
+            .postCode(DEC_ADD_PC).build();
+    private static final String EX_ADD_LINE1 = "ExLine1";
+    private static final String EX_ADD_PC = "ExPC";
+    private static final SolsAddress PRIMARY_ADDRESS = SolsAddress.builder().addressLine1(EX_ADD_LINE1)
+            .postCode(EX_ADD_PC).build();
+    private static final String PRIMARY_APPLICANT_APPLYING = "Yes";
+    private static final String PRIMARY_APPLICANT_HAS_ALIAS = "No";
+    private static final String OTHER_EXEC_EXISTS = "No";
+    private static final String WILL_EXISTS = "Yes";
+    private static final String WILL_ACCESS_ORIGINAL = "Yes";
+    private static final String PRIMARY_FORENAMES = "ExFN";
+    private static final String PRIMARY_SURNAME = "ExSN";
+    private static final String DECEASED_OTHER_NAMES = "No";
+    private static final String DECEASED_DOM_UK = "Yes";
+
+    private PebbleEngine pebble;
+    private String jsonData;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        pebble = new PebbleEngine.Builder()
+                .strictVariables(true)
+                .loader(new StringLoader())
+                .cacheActive(false)
+                .build();
+        CaseData caseData = CaseData.builder()
+                .deceasedDateOfBirth(DOB)
+                .deceasedDateOfDeath(DOD)
+                .deceasedForenames(FORENAME)
+                .deceasedSurname(SURNAME)
+                .deceasedAddress(DECEASED_ADDRESS)
+                .deceasedAnyOtherNames(DECEASED_OTHER_NAMES)
+                .deceasedDomicileInEngWales(DECEASED_DOM_UK)
+                .primaryApplicantForenames(PRIMARY_FORENAMES)
+                .primaryApplicantSurname(PRIMARY_SURNAME)
+                .primaryApplicantAddress(PRIMARY_ADDRESS)
+                .primaryApplicantIsApplying(PRIMARY_APPLICANT_APPLYING)
+                .primaryApplicantHasAlias(PRIMARY_APPLICANT_HAS_ALIAS)
+                .otherExecutorExists(OTHER_EXEC_EXISTS)
+                .willExists(WILL_EXISTS)
+                .willAccessOriginal(WILL_ACCESS_ORIGINAL)
+                .ihtNetValue(NET)
+                .ihtGrossValue(GROSS)
+                .solsSolicitorAppReference(SOLICITOR_APP_REFERENCE)
+                .willHasCodicils(WILL_HAS_CODICILS)
+                .willNumberOfCodicils(NUMBER_OF_CODICILS)
+                .solsSolicitorFirmName(SOLICITOR_FIRM_NAME)
+                .solsSolicitorFirmPostcode(SOLICITOR_FIRM_POSTCODE)
+                .solsIHTFormId(IHT_FORM)
+                .solsSOTName(SOLICITOR_NAME)
+                .solsSOTJobTitle(SOLICITOR_JOB_TITLE)
+                .solsPaymentMethods(PAYMENT_METHOD)
+                .applicationFee(APPLICATION_FEE)
+                .feeForUkCopies(FEE_FOR_UK_COPIES)
+                .feeForNonUkCopies(FEE_FOR_NON_UK_COPIES)
+                .extraCopiesOfGrant(EXTRA_UK)
+                .outsideUKGrantCopies(EXTRA_OUTSIDE_UK)
+                .totalFee(TOTAL_FEE)
+                .build();
+
+        CaseDetails caseDetails = new CaseDetails(caseData, LAST_MODIFIED, ID);
+        CallbackRequest callbackRequest = new CallbackRequest(caseDetails);
+
+        ObjectMapper otherObjectMapper = objectMapper.copy();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(BigDecimal.class, new BigDecimalNumberSerializer());
+        otherObjectMapper.registerModule(module);
+
+        jsonData = objectMapper.writeValueAsString(callbackRequest);
+    }
+
+    @Ignore
+    @Test
+    public void shouldGenerateCorrectHtml() throws Exception {
+        Map<String, Object> valuesMap = objectMapper.readValue(jsonData, MapType.REFERENCE);
+        String templateString = new String(Files.readAllBytes(Paths.get(getClass()
+                .getResource("/templates/pdf/legalStatement.html").toURI())));
+        Writer writer = new StringWriter();
+        PebbleTemplate pebbleTemplate = pebble.getTemplate(templateString);
+        pebbleTemplate.evaluate(writer, valuesMap);
+        String generatedHtml = writer.toString();
+        System.out.println(generatedHtml);
+    }
+
+    private static class MapType extends TypeReference<Map<String, Object>> {
+        private static final MapType REFERENCE = new MapType();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CCDDataTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CCDDataTransformerTest.java
@@ -39,8 +39,8 @@ public class CCDDataTransformerTest {
     private static final LocalDate DOD = LocalDate.parse("2017-12-31", dateTimeFormatter);
 
     private static final String IHT_FORM_ID = "IHT207";
-    private static final Float IHT_GROSS = 10000f;
-    private static final Float IHT_NET = 9000f;
+    private static final BigDecimal IHT_GROSS = BigDecimal.valueOf(10000f);
+    private static final BigDecimal IHT_NET = BigDecimal.valueOf(9000f);
     private static final BigDecimal TOTAL_FEE = new BigDecimal(155.00);
     private static final BigDecimal APPLICATION_FEE = new BigDecimal(200.00);
     private static final BigDecimal FEE_UK_COPIES = new BigDecimal(0.50);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.probate.transformer;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -57,8 +59,8 @@ public class CallbackResponseTransformerTest {
 
 
     private static final String IHT_FORM_ID = "IHT207";
-    private static final Float IHT_GROSS = 10000f;
-    private static final Float IHT_NET = 9000f;
+    private static final BigDecimal IHT_GROSS = BigDecimal.valueOf(10000f);
+    private static final BigDecimal IHT_NET = BigDecimal.valueOf(9000f);
 
     private static final String SOL_PAY_METHODS_FEE = "fee account";
     private static final String SOL_PAY_METHODS_CHEQUE = "cheque";
@@ -289,8 +291,8 @@ public class CallbackResponseTransformerTest {
         assertEquals(NUM_CODICILS, callbackResponse.getData().getWillNumberOfCodicils());
 
         assertEquals(IHT_FORM_ID, callbackResponse.getData().getSolsIHTFormId());
-        assertEquals("10000", callbackResponse.getData().getIhtGrossValue());
-        assertEquals("9000", callbackResponse.getData().getIhtNetValue());
+        Assert.assertThat(new BigDecimal("10000"),  comparesEqualTo(callbackResponse.getData().getIhtGrossValue()));
+        Assert.assertThat(new BigDecimal("9000"),  comparesEqualTo(callbackResponse.getData().getIhtNetValue()));
 
         assertEquals(APPLICANT_FORENAME, callbackResponse.getData().getPrimaryApplicantForenames());
         assertEquals(APPLICANT_SURNAME, callbackResponse.getData().getPrimaryApplicantSurname());

--- a/src/test/java/uk/gov/hmcts/probate/validator/IHTValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/IHTValidationRuleTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.probate.model.ccd.CCDData;
 import uk.gov.hmcts.probate.model.ccd.InheritanceTax;
 import uk.gov.hmcts.probate.service.BusinessValidationMessageService;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,8 +28,8 @@ import static uk.gov.hmcts.probate.validator.IHTValidationRule.IHT_NET_GREATER_T
 @RunWith(MockitoJUnitRunner.class)
 public class IHTValidationRuleTest {
 
-    private static final float HIGHER_VALUE = 20f;
-    private static final float LOWER_VALUE = 1f;
+    private static final BigDecimal HIGHER_VALUE = BigDecimal.valueOf(20f);
+    private static final BigDecimal LOWER_VALUE = BigDecimal.valueOf(1f);
 
     @Mock
     private BusinessValidationMessageService businessValidationMessageService;


### PR DESCRIPTION
### Change description ###
- Changed IHT values to BigDecimal, float was rounding numbers with a large number of digits.
- 2 ObjectMappers now, primary one which converts BigDecimal to JSON string, and one for PDF service which converts BigDecimal to JSON number - this is required for the pebble template for the legal statement.
- Updated tests, also created a utility test (currently set to ignore), just to check our pebble template is working for PDF service.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
