### PR TITLE
PRO-3236: Add Payment Details

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/Payment.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/Payment.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.probate.model.ccd.raw;
+
+import lombok.Data;
+
+@Data
+public class Payment {
+
+    private final String status;
+    private final String date;
+    private final String reference;
+    private final String amount;
+    private final String method;
+    private final String transactionId;
+    private final String siteId;
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/Payment.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/Payment.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.probate.model.ccd.raw;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class Payment {
 
     private final String status;

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.Declaration;
 import uk.gov.hmcts.probate.model.ccd.raw.Document;
 import uk.gov.hmcts.probate.model.ccd.raw.DocumentLink;
 import uk.gov.hmcts.probate.model.ccd.raw.LegalStatement;
+import uk.gov.hmcts.probate.model.ccd.raw.Payment;
 import uk.gov.hmcts.probate.model.ccd.raw.ProbateAliasName;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.StopReason;
@@ -239,6 +240,8 @@ public class CaseData {
     private final String boAdminClauseLimitation;
 
     private final String boLimitationText;
+
+    private final List<CollectionMember<Payment>> payments;
 
     @Getter(lazy = true)
     private final List<CollectionMember<AdditionalExecutor>> executorsApplyingForLegalStatement = getAllExecutors(true);

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.Declaration;
 import uk.gov.hmcts.probate.model.ccd.raw.Document;
 import uk.gov.hmcts.probate.model.ccd.raw.DocumentLink;
 import uk.gov.hmcts.probate.model.ccd.raw.LegalStatement;
+import uk.gov.hmcts.probate.model.ccd.raw.Payment;
 import uk.gov.hmcts.probate.model.ccd.raw.ProbateAliasName;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.StopReason;
@@ -106,4 +107,6 @@ public class ResponseCaseData {
     //Todo remove PA specific attr
     private final String primaryApplicantPhoneNumber;
 
+    private final List<CollectionMember<Payment>> payments;
+    
 }

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -219,7 +219,9 @@ public class CallbackResponseTransformer {
                 .primaryApplicantPhoneNumber(caseData.getPrimaryApplicantPhoneNumber())
                 .declaration(caseData.getDeclaration())
                 .legalStatement(caseData.getLegalStatement())
-                .deceasedMarriedAfterWillOrCodicilDate(caseData.getDeceasedMarriedAfterWillOrCodicilDate());
+                .deceasedMarriedAfterWillOrCodicilDate(caseData.getDeceasedMarriedAfterWillOrCodicilDate())
+
+                .payments(caseData.getPayments());
 
         if (transform) {
             updateCaseBuilderForTransformCase(caseData, builder);

--- a/src/main/resources/templates/printService/caseDetailsPA.html
+++ b/src/main/resources/templates/printService/caseDetailsPA.html
@@ -129,10 +129,6 @@
     <td>{% if case_data.ihtNetValue %}&pound;{{ (case_data.ihtNetValue/100) | money('0,0.00') }}{% endif %}</td>
   </tr>
   <tr>
-    <td colspan="2">Payment reference:</td>
-    <td>{% if case_data.paymentReferenceNumber %}{{ case_data.paymentReferenceNumber }}{% endif %}</td>
-  </tr>
-  <tr>
     <td colspan="3">&nbsp;</td>
   </tr>
   <tr>

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataJsonTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataJsonTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.probate.model.ccd.raw.request;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.probate.util.TestUtils;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+public class CaseDataJsonTest {
+
+    private String jsonContent;
+
+    @Autowired
+    private JacksonTester<CaseData> jacksonTester;
+
+    private TestUtils testUtils = new TestUtils();
+
+    @Before
+    public void setUp() throws IOException {
+        jsonContent = testUtils.getStringFromFile("paCaseData.json");
+    }
+
+    @Test
+    public void shouldDeserializePaymentsCorrectly() throws Exception {
+        CaseData caseData = jacksonTester.parseObject(jsonContent);
+        assertThat(caseData.getPayments(), Matchers.hasSize(1));
+        assertThat(caseData.getPayments().get(0).getValue().getAmount(), is("27000"));
+        assertThat(caseData.getPayments().get(0).getValue().getDate(), is("2018-09-17"));
+        assertThat(caseData.getPayments().get(0).getValue().getMethod(), is("online"));
+        assertThat(caseData.getPayments().get(0).getValue().getReference(), is("RC-1537-1988-5489-1985"));
+        assertThat(caseData.getPayments().get(0).getValue().getSiteId(), is("P223"));
+        assertThat(caseData.getPayments().get(0).getValue().getStatus(), is("Success"));
+        assertThat(caseData.getPayments().get(0).getValue().getTransactionId(), is("r23k178busa0rp2mh27m0vchja"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.AliasName;
 import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.Document;
 import uk.gov.hmcts.probate.model.ccd.raw.DocumentLink;
+import uk.gov.hmcts.probate.model.ccd.raw.Payment;
 import uk.gov.hmcts.probate.model.ccd.raw.ProbateAliasName;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.StopReason;
@@ -32,11 +33,13 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.list;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -139,6 +142,18 @@ public class CallbackResponseTransformerTest {
     private static final String ADMIN_CLAUSE_LIMITATION = "Admin Clause Limitation";
     private static final String TOTAL_FEE = "6600";
 
+    private static final List<CollectionMember<Payment>> PAYMENTS_LIST = Arrays.asList(
+            new CollectionMember("id",
+                    Payment.builder()
+                            .amount("100")
+                            .date("20/09/2018")
+                            .method("online")
+                            .reference("Reference-123")
+                            .status("Success")
+                            .siteId("SiteId-123")
+                            .transactionId("TransactionId-123")
+                            .build()));
+
     @InjectMocks
     private CallbackResponseTransformer underTest;
 
@@ -214,7 +229,8 @@ public class CallbackResponseTransformerTest {
                 .boAdminClauseLimitation(ADMIN_CLAUSE_LIMITATION)
                 .boLimitationText(LIMITATION_TEXT)
                 .ihtReferenceNumber(IHT_REFERENCE)
-                .ihtFormCompletedOnline(IHT_ONLINE);
+                .ihtFormCompletedOnline(IHT_ONLINE)
+                .payments(PAYMENTS_LIST);
 
         when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
@@ -701,6 +717,8 @@ public class CallbackResponseTransformerTest {
 
         assertEquals(IHT_REFERENCE, callbackResponse.getData().getIhtReferenceNumber());
         assertEquals(IHT_ONLINE, callbackResponse.getData().getIhtFormCompletedOnline());
+
+        assertEquals(PAYMENTS_LIST, callbackResponse.getData().getPayments());
     }
 
     private void assertApplicationType(CallbackResponse callbackResponse, ApplicationType applicationType) {

--- a/src/test/resources/paCaseData.json
+++ b/src/test/resources/paCaseData.json
@@ -1,0 +1,84 @@
+{
+  "outsideUKGrantCopies": 0,
+  "applicationType": "Personal",
+  "deceasedAddress": {
+    "AddressLine1": "zxccx"
+  },
+  "deceasedAnyOtherNames": "No",
+  "payments": [
+    {
+      "value": {
+        "status": "Success",
+        "date": "2018-09-17",
+        "reference": "RC-1537-1988-5489-1985",
+        "amount": "27000",
+        "method": "online",
+        "transactionId": "r23k178busa0rp2mh27m0vchja",
+        "siteId": "P223"
+      },
+      "id": "dec627d3-f2da-4c47-8885-077fd3fe9ae8"
+    }
+  ],
+  "willHasCodicils": "No",
+  "deceasedDateOfBirth": "1980-01-01",
+  "willAccessOriginal": "Yes",
+  "primaryApplicantEmailAddress": "E5wqQl-c9svjgkGj2Wo3JRMNvJJU42ii",
+  "willExists": "Yes",
+  "executorsNotApplying": [],
+  "deceasedDateOfDeath": "2018-01-01",
+  "primaryApplicantForenames": "asdasas",
+  "primaryApplicantAddress": {
+    "AddressLine1": "dsasds"
+  },
+  "applicationSubmittedDate": "2018-09-17",
+  "deceasedDomicileInEngWales": "Yes",
+  "ihtNetValue": "20000000",
+  "ihtReferenceNumber": "sdasasaddas",
+  "primaryApplicantPhoneNumber": "234234314",
+  "applicationID": 265,
+  "deceasedMarriedAfterWillOrCodicilDate": "No",
+  "softStop": "No",
+  "deceasedSurname": "Jonathan",
+  "extraCopiesOfGrant": 111,
+  "numberOfExecutors": 1,
+  "deceasedForenames": "Jon Jonny",
+  "declaration": {
+    "accept": "I confirm that I will administer the estate of the person who died according to law, and that my application is truthful.",
+    "confirm": "I confirm that we will administer the estate of Jon Jonny Jonathan, according to law. I will:",
+    "requests": "If the probate registry (court) asks me to do so, I will:",
+    "understand": "I understand that:",
+    "confirmItem1": "collect the whole estate",
+    "confirmItem2": "keep full details (an inventory) of the estate",
+    "confirmItem3": "keep a full account of how the estate has been administered",
+    "requestsItem1": "provide the full details of the estate and how it has been administered",
+    "requestsItem2": "return the grant of probate to the court",
+    "understandItem1": "my application will be rejected if I do not answer any questions about the information I have given",
+    "understandItem2": "criminal proceedings for fraud may be brought against me if I am found to have been deliberately untruthful or dishonest"
+  },
+  "numberOfApplicants": 1,
+  "primaryApplicantIsApplying": "Yes",
+  "executorsApplying": [],
+  "totalFee": "27050",
+  "ihtGrossValue": "20000000",
+  "ihtFormCompletedOnline": "Yes",
+  "registryLocation": "Oxford",
+  "primaryApplicantSurname": "asdasdasd",
+  "legalStatement": {
+    "intro": "This statement is based on the information you&rsquo;ve given in your application. It will be stored as a public record.",
+    "deceased": "Jon Jonny Jonathan was born on 1 January 1980 and died on 1 January 2018, domiciled in England and Wales.",
+    "applicant": "I, asdasas asdasdasd of dsasds, make the following statement:",
+    "executorsApplying": [
+      {
+        "id": "0a20b5fc-ba55-4972-8c5b-1cd7d25710cc",
+        "value": {
+          "name": "I am an executor named in the will as asdasas asdasdasd, and I am applying for probate.",
+          "sign": "I will sign and send to the probate registry what I believe to be the true and original last will and testament of Jon Jonny Jonathan."
+        }
+      }
+    ],
+    "deceasedEstateLand": "To the best of my knowledge, information and belief, there was no land vested in Jon Jonny Jonathan which was settled previously to the death (and not by the will) of Jon Jonny Jonathan and which remained settled land notwithstanding such death.",
+    "deceasedOtherNames": "",
+    "deceasedEstateValue": "The gross value for the estate amounts to &pound;200000 and the net value for the estate amounts to &pound;200000.",
+    "executorsNotApplying": []
+  }
+}


### PR DESCRIPTION
Add payment details to the request and response objects for CCD data, to ensure it does not get lost in back office journeys.

Also removed payment reference from print - as it is no longer valid.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
