### PR TITLE
PRO-3765 Changes to support PA Applicant Alias

### DIFF
--- a/src/functionalTest/resources/json/success.beforeSignSOT.checkYourAnswersPayload.json
+++ b/src/functionalTest/resources/json/success.beforeSignSOT.checkYourAnswersPayload.json
@@ -69,7 +69,7 @@
             "primaryApplicantHasAlias": "Yes",
             "ihtFormId": "IHT205",
             "ihtGrossValue": "100001",
-            "solsExecutorAliasNames": "ex1wn",
+            "solsExecutorAliasNames": "TestPrimaryExecutorAliasName",
             "primaryApplicantSurname": "Ex1ln",
             "solsSolicitorAppReference": "appref",
             "solsSOTNeedToUpdate":"Yes"

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/AdditionalExecutorApplying.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/AdditionalExecutorApplying.java
@@ -11,6 +11,8 @@ public class AdditionalExecutorApplying {
     private final String applyingExecutorPhoneNumber;
     private final String applyingExecutorEmail;
     private String applyingExecutorOtherNames;
+    private String applyingExecutorOtherNamesReason;
+    private String applyingExecutorOtherReason;
     private final SolsAddress applyingExecutorAddress;
 
 

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -128,7 +128,15 @@ public class CaseData {
     @NotBlank(groups = {ApplicationUpdatedGroup.class}, message = "{primaryApplicantHasAliasIsNull}")
     private final String primaryApplicantHasAlias;
 
+    private final String primaryApplicantAlias;
+
+    private final String primaryApplicantAliasReason;
+
+    private final String primaryApplicantOtherReason;
+
     private final String solsExecutorAliasNames;
+
+    private final String primaryApplicantSameWillName;
 
     @NotBlank(groups = {ApplicationUpdatedGroup.class}, message = "{primaryApplicantIsApplyingIsNull}")
     private final String primaryApplicantIsApplying;

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/response/ResponseCaseData.java
@@ -74,6 +74,10 @@ public class ResponseCaseData {
     private final String primaryApplicantIsApplying;
     private final String solsPrimaryExecutorNotApplyingReason;
     private final String otherExecutorExists;
+    private final String primaryApplicantAlias;
+    private final String primaryApplicantSameWillName;
+    private final String primaryApplicantAliasReason;
+    private final String primaryApplicantOtherReason;
     private final String solsExecutorAliasNames;
     @JsonProperty(value = "executorsApplying")
     private final List<CollectionMember<AdditionalExecutorApplying>> additionalExecutorsApplying;

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -47,6 +47,7 @@ public class CallbackResponseTransformer {
     public static final String ANSWER_YES = "Yes";
     public static final String ANSWER_NO = "No";
     public static final String QA_CASE_STATE = "BOCaseQA";
+    public static final String OTHER = "other";
 
     public CallbackResponse transformWithConditionalStateChange(CallbackRequest callbackRequest, Optional<String> newState) {
         ResponseCaseData responseCaseData = getResponseCaseData(callbackRequest.getCaseDetails(), false)
@@ -169,7 +170,9 @@ public class CallbackResponseTransformer {
                 .solsPrimaryExecutorNotApplyingReason(caseData.getSolsPrimaryExecutorNotApplyingReason())
                 .primaryApplicantHasAlias(getPrimaryApplicantHasAlias(caseData))
                 .otherExecutorExists(getOtherExecutorExists(caseData))
-                .solsExecutorAliasNames(caseData.getSolsExecutorAliasNames())
+                .primaryApplicantSameWillName(caseData.getPrimaryApplicantSameWillName())
+                .primaryApplicantAliasReason(caseData.getPrimaryApplicantAliasReason())
+                .primaryApplicantOtherReason(caseData.getPrimaryApplicantOtherReason())
                 .deceasedAddress(caseData.getDeceasedAddress())
                 .deceasedAnyOtherNames(caseData.getDeceasedAnyOtherNames())
                 .primaryApplicantAddress(caseData.getPrimaryApplicantAddress())
@@ -250,6 +253,16 @@ public class CallbackResponseTransformer {
             }
         }
 
+        if (caseData.getPrimaryApplicantAliasReason() != null) {
+            if (caseData.getPrimaryApplicantAliasReason().equalsIgnoreCase(OTHER)) {
+                builder
+                        .primaryApplicantOtherReason(caseData.getPrimaryApplicantOtherReason());
+            } else {
+                builder
+                        .primaryApplicantOtherReason(null);
+            }
+        }
+
         List<CollectionMember<AliasName>> deceasedAliasNames = EMPTY_LIST;
         if (caseData.getDeceasedAliasNameList() != null) {
             deceasedAliasNames = caseData.getDeceasedAliasNameList()
@@ -271,13 +284,25 @@ public class CallbackResponseTransformer {
         builder
                 .additionalExecutorsApplying(caseData.getAdditionalExecutorsApplying())
                 .additionalExecutorsNotApplying(caseData.getAdditionalExecutorsNotApplying())
-                .solsAdditionalExecutorList(caseData.getSolsAdditionalExecutorList());
+                .solsAdditionalExecutorList(caseData.getSolsAdditionalExecutorList())
+                .primaryApplicantAlias(caseData.getPrimaryApplicantAlias())
+                .solsExecutorAliasNames(caseData.getSolsExecutorAliasNames());
     }
 
     private void updateCaseBuilderForTransformCase(CaseData caseData, ResponseCaseDataBuilder builder) {
         builder
                 .ihtReferenceNumber(caseData.getIhtReferenceNumber())
                 .solsDeceasedAliasNamesList(caseData.getSolsDeceasedAliasNamesList());
+
+        if (caseData.getSolsExecutorAliasNames() != null) {
+            builder
+                    .primaryApplicantAlias(caseData.getSolsExecutorAliasNames())
+                    .solsExecutorAliasNames(null);
+        } else {
+            builder
+                    .primaryApplicantAlias(caseData.getPrimaryApplicantAlias())
+                    .solsExecutorAliasNames(caseData.getSolsExecutorAliasNames());
+        }
 
         if (CollectionUtils.isEmpty(caseData.getSolsAdditionalExecutorList())) {
             builder

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
@@ -69,7 +69,7 @@ public class CaseDataTest {
                 .primaryApplicantForenames(PRIMARY_APPLICANT_SURNAME)
                 .primaryApplicantIsApplying(YES)
                 .primaryApplicantAddress(PRIMARY_APPLICANT_ADDRESS)
-                .solsExecutorAliasNames(PRIMARY_APPLICANT_NAME_ON_WILL)
+                .primaryApplicantAlias(PRIMARY_APPLICANT_NAME_ON_WILL)
                 .solsAdditionalExecutorList(additionalExecutorsList)
                 .build();
     }
@@ -146,7 +146,7 @@ public class CaseDataTest {
                 .primaryApplicantForenames(PRIMARY_APPLICANT_SURNAME)
                 .primaryApplicantIsApplying(NO)
                 .primaryApplicantAddress(PRIMARY_APPLICANT_ADDRESS)
-                .solsExecutorAliasNames(PRIMARY_APPLICANT_NAME_ON_WILL)
+                .primaryApplicantAlias(PRIMARY_APPLICANT_NAME_ON_WILL)
                 .solsAdditionalExecutorList(additionalExecutorsList)
                 .build();
     }

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -209,6 +209,7 @@ public class CallbackResponseTransformerTest {
                 .primaryApplicantIsApplying(PRIMARY_EXEC_APPLYING)
                 .primaryApplicantHasAlias(APPLICANT_HAS_ALIAS)
                 .otherExecutorExists(OTHER_EXECS_EXIST)
+                .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
                 .solsExecutorAliasNames(PRIMARY_EXEC_ALIAS_NAMES)
                 .solsAdditionalExecutorList(ADDITIONAL_EXEC_LIST)
                 .deceasedAddress(DECEASED_ADDRESS)
@@ -581,6 +582,47 @@ public class CallbackResponseTransformerTest {
     }
 
     @Test
+    public void shouldTransformCaseForPAWithPrimaryApplicantAlias() {
+        caseDataBuilder.primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES);
+        caseDataBuilder.primaryApplicantSameWillName(YES);
+        caseDataBuilder.primaryApplicantAliasReason("Other");
+        caseDataBuilder.primaryApplicantOtherReason("Married");
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+        assertEquals(YES, callbackResponse.getData().getPrimaryApplicantSameWillName());
+        assertEquals(PRIMARY_EXEC_ALIAS_NAMES, callbackResponse.getData().getPrimaryApplicantAlias());
+        assertEquals("Other", callbackResponse.getData().getPrimaryApplicantAliasReason());
+        assertEquals("Married", callbackResponse.getData().getPrimaryApplicantOtherReason());
+    }
+    @Test
+    public void shouldTransformCaseForPAWithPrimaryApplicantAliasOtherToBeNull() {
+        caseDataBuilder.primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES);
+        caseDataBuilder.primaryApplicantSameWillName(YES);
+        caseDataBuilder.primaryApplicantAliasReason("Marriage");
+        caseDataBuilder.primaryApplicantOtherReason("Married");
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+        assertEquals(YES, callbackResponse.getData().getPrimaryApplicantSameWillName());
+        assertEquals(PRIMARY_EXEC_ALIAS_NAMES, callbackResponse.getData().getPrimaryApplicantAlias());
+        assertEquals("Marriage", callbackResponse.getData().getPrimaryApplicantAliasReason());
+        assertEquals(null, callbackResponse.getData().getPrimaryApplicantOtherReason());
+    }
+    @Test
+    public void shouldTransformCaseForPAWithApplyExecAlias() {
+        List<CollectionMember<AdditionalExecutorApplying>> additionalExecsList = new ArrayList<>();
+        additionalExecsList.add(createAdditionalExecutorApplying("0"));
+        additionalExecsList.add(createAdditionalExecutorApplying("1"));
+        caseDataBuilder.additionalExecutorsApplying(additionalExecsList);
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+        assertCommonDetails(callbackResponse);
+        assertEquals(2, callbackResponse.getData().getAdditionalExecutorsApplying().size());
+    }
+
+    @Test
     public void shouldTransformCaseForPAWithIHTOnlineNo() {
         caseDataBuilder.applicationType(ApplicationType.PERSONAL);
         caseDataBuilder.ihtFormCompletedOnline(NO);
@@ -653,6 +695,8 @@ public class CallbackResponseTransformerTest {
                 .applyingExecutorName(EXEC_FIRST_NAME + " " + EXEC_SURNAME)
                 .applyingExecutorOtherNames(ALIAS_FORENAME + " " + ALIAS_SURNAME)
                 .applyingExecutorPhoneNumber(EXEC_PHONE)
+                .applyingExecutorOtherNamesReason("Other")
+                .applyingExecutorOtherReason("Married")
                 .build();
         return new CollectionMember<>(id, add1na);
     }
@@ -671,6 +715,8 @@ public class CallbackResponseTransformerTest {
     private void assertApplyingExecutorDetails(AdditionalExecutorApplying exec) {
         assertEquals(EXEC_FIRST_NAME + " " + EXEC_SURNAME, exec.getApplyingExecutorName());
         assertEquals(ALIAS_FORENAME + " " + ALIAS_SURNAME, exec.getApplyingExecutorOtherNames());
+        assertEquals("Other", exec.getApplyingExecutorOtherNamesReason());
+        assertEquals("Married",  exec.getApplyingExecutorOtherReason());
         assertApplyingExecutorDetailsFromSols(exec);
     }
 
@@ -720,7 +766,7 @@ public class CallbackResponseTransformerTest {
         assertEquals(APPLICANT_SURNAME, callbackResponse.getData().getPrimaryApplicantSurname());
         assertEquals(APPLICANT_EMAIL_ADDRESS, callbackResponse.getData().getPrimaryApplicantEmailAddress());
         assertEquals(PRIMARY_EXEC_APPLYING, callbackResponse.getData().getPrimaryApplicantIsApplying());
-        assertEquals(PRIMARY_EXEC_ALIAS_NAMES, callbackResponse.getData().getSolsExecutorAliasNames());
+        assertEquals(PRIMARY_EXEC_ALIAS_NAMES, callbackResponse.getData().getPrimaryApplicantAlias());
         assertEquals(DECEASED_ADDRESS, callbackResponse.getData().getDeceasedAddress());
         assertEquals(EXEC_ADDRESS, callbackResponse.getData().getPrimaryApplicantAddress());
         assertEquals(APP_REF, callbackResponse.getData().getSolsSolicitorAppReference());

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -595,6 +595,7 @@ public class CallbackResponseTransformerTest {
         assertEquals("Other", callbackResponse.getData().getPrimaryApplicantAliasReason());
         assertEquals("Married", callbackResponse.getData().getPrimaryApplicantOtherReason());
     }
+
     @Test
     public void shouldTransformCaseForPAWithPrimaryApplicantAliasOtherToBeNull() {
         caseDataBuilder.primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES);
@@ -609,6 +610,7 @@ public class CallbackResponseTransformerTest {
         assertEquals("Marriage", callbackResponse.getData().getPrimaryApplicantAliasReason());
         assertEquals(null, callbackResponse.getData().getPrimaryApplicantOtherReason());
     }
+
     @Test
     public void shouldTransformCaseForPAWithApplyExecAlias() {
         List<CollectionMember<AdditionalExecutorApplying>> additionalExecsList = new ArrayList<>();
@@ -716,7 +718,7 @@ public class CallbackResponseTransformerTest {
         assertEquals(EXEC_FIRST_NAME + " " + EXEC_SURNAME, exec.getApplyingExecutorName());
         assertEquals(ALIAS_FORENAME + " " + ALIAS_SURNAME, exec.getApplyingExecutorOtherNames());
         assertEquals("Other", exec.getApplyingExecutorOtherNamesReason());
-        assertEquals("Married",  exec.getApplyingExecutorOtherReason());
+        assertEquals("Married", exec.getApplyingExecutorOtherReason());
         assertApplyingExecutorDetailsFromSols(exec);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3765

### Change description ###
Additional fields to track why there is an alias name for Primary Applicant and Applying Executors.
Data alignment to convert solsExecutorAliasNames to PrimaryApplicantAlias.

Already approved for AAT, these changes are for demo branch of code (https://github.com/hmcts/probate-sol-ccd-services/pull/165)

Requires new spreadsheet https://github.com/hmcts/Probate-CCD-Import-Spreadsheets/blob/master/spreadsheet/back-office/CCD_Probate_V03.30-Dev.xlsx

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
