### PR TITLE
Pro 2795 remove escaped characters in declarartion

### DIFF
--- a/src/main/resources/templates/printService/caseDetailsPA.html
+++ b/src/main/resources/templates/printService/caseDetailsPA.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<meta charset="UTF-8"/>
 {% macro names(forenames, surname) %}{{ forenames }} {{ surname }}{% endmacro %}
 {% macro notApplyingReason(reason) %}{% if reason == "DiedBefore" %}They died before the deceased.{% endif %}{% if reason == "DiedAfter"%}They died after the deceased.{% endif %}{% if reason == "PowerReserved" %}They're holding power reserved.{% endif%}{% if reason == "Renunciation" %}They have renounced.{% endif %}{% endmacro %}
 {% macro replaceAllEncoded(original) %}{{ original | replace('&rsquo;', '’')  | replace('&pound;', '&pound;') }}{% endmacro %}


### PR DESCRIPTION
PRO-2795: need to remove encoded chars in the legal statement + delclaration for PA applications when doing Print from ccd-ui
[ ] Yes
[X ] No
```
