### PR TITLE
Pro 4526 add subtype to scanned documents

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/businessvalidation/SolCcdServiceBusinessValidationTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/businessvalidation/SolCcdServiceBusinessValidationTests.java
@@ -227,6 +227,7 @@ public class SolCcdServiceBusinessValidationTests extends IntegrationTestBase {
         String controlNumber = jsonPath.get("data.scannedDocuments[0].value.controlNumber");
         String fileName = jsonPath.get("data.scannedDocuments[0].value.fileName");
         String type = jsonPath.get("data.scannedDocuments[0].value.type");
+        String subtype = jsonPath.get("data.scannedDocuments[0].value.subtype");
         String documentUrl = jsonPath.get("data.scannedDocuments[0].value.url.document_url");
         String documentBinaryUrl = jsonPath.get("data.scannedDocuments[0].value.url.document_binary_url");
         String documentFilename = jsonPath.get("data.scannedDocuments[0].value.url.document_filename");
@@ -235,6 +236,7 @@ public class SolCcdServiceBusinessValidationTests extends IntegrationTestBase {
         assertEquals("1234", controlNumber);
         assertEquals("scanneddocument.pdf", fileName);
         assertEquals("other", type);
+        assertEquals("will", subtype);
         assertEquals("http://somedoc", documentUrl);
         assertEquals("http://somedoc.pdf/binary", documentBinaryUrl);
         assertEquals("somedoc.pdf", documentFilename);

--- a/src/functionalTest/resources/json/success.scannedDocuments.json
+++ b/src/functionalTest/resources/json/success.scannedDocuments.json
@@ -223,6 +223,7 @@
             "controlNumber": "1234",
             "fileName": "scanneddocument.pdf",
             "type": "other",
+            "subtype": "will",
             "scannedDate": "2018-01-01T12:34:56.123",
             "url": {
               "document_url": "http://somedoc",

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/ScannedDocument.java
@@ -16,6 +16,8 @@ public class ScannedDocument {
     private final String fileName;
 
     private final String type;
+    
+    private final String subtype;
 
     private final LocalDateTime scannedDate;
 

--- a/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/BusinessValidationControllerTest.java
@@ -105,6 +105,7 @@ public class BusinessValidationControllerTest {
                             .controlNumber("1234")
                             .scannedDate(scannedDate)
                             .type("other")
+                            .subtype("will")
                             .url(SCANNED_DOCUMENT_URL)
                             .build()));
 

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -178,7 +178,7 @@ public class CallbackResponseTransformerTest {
                             .controlNumber("1234")
                             .scannedDate(scannedDate)
                             .type("other")
-                            .subtype("other")
+                            .subtype("will")
                             .url(SCANNED_DOCUMENT_URL)
                             .build()));
     

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -178,6 +178,7 @@ public class CallbackResponseTransformerTest {
                             .controlNumber("1234")
                             .scannedDate(scannedDate)
                             .type("other")
+                            .subtype("other")
                             .url(SCANNED_DOCUMENT_URL)
                             .build()));
     

--- a/src/test/resources/scannedDocuments.json
+++ b/src/test/resources/scannedDocuments.json
@@ -79,6 +79,7 @@
             "controlNumber": "1234",
             "fileName": "scanneddocument.pdf",
             "type": "other",
+            "subtype": "will",
             "scannedDate": "2018-01-01T12:34:56.123",
             "url": {
               "document_url": "http://somedoc",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-4526

### Change description ###
Included subtype field to ScannedDocument as requested by the Bulk Scanning team. This field indicates what the document is if 'type' is 'other'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
