### PR TITLE
PRO-4668: created endpoints for data extract for iron mountain and excela

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/dataextract/DataExtractTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/dataextract/DataExtractTests.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.probate.functional.dataextract;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.rest.SerenityRest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.hmcts.probate.functional.IntegrationTestBase;
+
+@RunWith(SerenityRunner.class)
+public class DataExtractTests extends IntegrationTestBase {
+    private static final String IRONMOUNTAIN_URL = "/data-extract/iron-mountain";
+    private static final String EXCELA_URL = "/data-extract/excela";
+
+    @Value("${probate.caseworker.email}")
+    private String email;
+
+    @Value("${probate.caseworker.password}")
+    private String password;
+
+    @Value("${probate.caseworker.id}")
+    private Integer id;
+
+    @Test
+    public void verifyValidRequestReturnsOkStatusForIronMountain() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(IRONMOUNTAIN_URL)
+                .then().assertThat().statusCode(200);
+    }
+
+    @Test
+    public void verifyValidDateRequestReturnsOkStatusForIronMountain() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(IRONMOUNTAIN_URL + "/2019-02-03")
+                .then().assertThat().statusCode(200);
+    }
+
+    @Test
+    public void verifyIncorrectDateFormatReturnsBadRequestForIronMountain() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(IRONMOUNTAIN_URL + "/2019-2-2")
+                .then().assertThat().statusCode(400);
+    }
+
+    @Test
+    public void verifyValidRequestReturnsOkStatusForExcela() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(EXCELA_URL)
+                .then().assertThat().statusCode(200);
+    }
+
+    @Test
+    public void verifyValidDateRequestReturnsOkStatusForExcela() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(EXCELA_URL + "/2019-02-03")
+                .then().assertThat().statusCode(200);
+    }
+
+    @Test
+    public void verifyIncorrectDateFormatReturnsBadRequestForExcela() {
+        SerenityRest.given().relaxedHTTPSValidation().headers(utils.getHeaders(email,
+                password, id))
+                .when()
+                .post(EXCELA_URL + "/2019-2-2")
+                .then().assertThat().statusCode(400);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/config/SwaggerConfig.java
+++ b/src/main/java/uk/gov/hmcts/probate/config/SwaggerConfig.java
@@ -16,9 +16,6 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.List;
-
-import static java.util.Collections.singletonList;
 
 @EnableSwagger2
 @Configuration

--- a/src/main/java/uk/gov/hmcts/probate/config/SwaggerConfig.java
+++ b/src/main/java/uk/gov/hmcts/probate/config/SwaggerConfig.java
@@ -9,11 +9,14 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Parameter;
+import springfox.documentation.service.Tag;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 
@@ -24,16 +27,20 @@ public class SwaggerConfig {
     @Bean
     public Docket validationApi() {
         return new Docket(DocumentationType.SWAGGER_2)
-            .globalOperationParameters(singletonList(parameterBuilder()))
-            .directModelSubstitute(LocalDate.class, java.sql.Date.class)
-            .apiInfo(apiInfo())
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("uk.gov.hmcts.probate.controller"))
-            .paths(PathSelectors.any())
-            .build();
+                .globalOperationParameters(Arrays.asList(serviceAuthorizationParameterBuilder(),
+                        authorizationParameterBuilder()))
+                .directModelSubstitute(LocalDate.class, java.sql.Date.class)
+                .apiInfo(apiInfo())
+                .tags(new Tag("tag1", "Tag 1 description."),
+                        new Tag("tag2", "Tag 2 description."),
+                        new Tag("tag2", "Tag 3 description."))
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("uk.gov.hmcts.probate.controller"))
+                .paths(PathSelectors.any())
+                .build();
     }
 
-    private Parameter parameterBuilder() {
+    private Parameter serviceAuthorizationParameterBuilder() {
         return new ParameterBuilder()
                 .name("ServiceAuthorization")
                 .description("User authorization header")
@@ -43,12 +50,22 @@ public class SwaggerConfig {
                 .build();
     }
 
+    private Parameter authorizationParameterBuilder() {
+        return new ParameterBuilder()
+                .name("Authorization")
+                .description("Authorization header")
+                .required(true)
+                .parameterType("header")
+                .modelRef(new ModelRef("string"))
+                .build();
+    }
+
     private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-            .title("Solicitor CCD service")
-            .description("Provides data validation and other services")
-            .license("MIT License")
-            .version("1.0")
-            .build();
+                .title("Solicitor CCD service")
+                .description("Provides data validation and other services")
+                .license("MIT License")
+                .version("1.0")
+                .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.probate.controller;
+
+import com.google.common.collect.ImmutableList;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.probate.exception.ClientException;
+import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
+import uk.gov.hmcts.probate.model.ccd.raw.ScannedDocument;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
+import uk.gov.hmcts.probate.service.CaseQueryService;
+import uk.gov.hmcts.probate.service.NotificationService;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import static uk.gov.hmcts.probate.model.Constants.DOC_SUBTYPE_WILL;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/data-extract")
+@RestController
+@Api(tags = "Initiate data extract for IronMountain and Excela")
+public class DataExtractController {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private final CaseQueryService caseQueryService;
+    private final NotificationService notificationService;
+
+    @ApiOperation(value = "Initiate IronMountain data extract", notes = "Will find cases for yesterdays date")
+    @PostMapping(path = "/iron-mountain")
+    public ResponseEntity initiateIronMountainExtract() {
+        return initiateIronMountainExtract(DATE_FORMAT.format(LocalDate.now().minusDays(1L)));
+    }
+
+    @ApiOperation(value = "Initiate IronMountain data extract with date", notes = "Date MUST be in format 'yyyy-MM-dd'")
+    @PostMapping(path = "/iron-mountain/{date}")
+    public ResponseEntity initiateIronMountainExtract(@ApiParam(value = "Date to find cases against", required = true)
+                                                      @PathVariable("date") String date) {
+        dateValidator(date);
+
+        List<ReturnedCaseDetails> cases = caseQueryService.findCasesWithDatedDocument("digitalGrant", date);
+
+        return ResponseEntity.ok(cases.size() + " cases successfully found for date: " + date);
+    }
+
+    @ApiOperation(value = "Initiate Excela data extract", notes = "Will find cases for yesterdays date")
+    @PostMapping(path = "/excela")
+    public ResponseEntity initiateExcelaExtract() throws NotificationClientException {
+        return initiateExcelaExtract(DATE_FORMAT.format(LocalDate.now().minusDays(1L)));
+    }
+
+    @ApiOperation(value = "Initiate Excela data extract", notes = " Date MUST be in format 'yyyy-MM-dd'")
+    @PostMapping(path = "/excela/{date}")
+    public ResponseEntity initiateExcelaExtract(@ApiParam(value = "Date to find cases against", required = true)
+                                                @PathVariable("date") String date) throws NotificationClientException {
+        dateValidator(date);
+
+        List<ReturnedCaseDetails> cases = caseQueryService.findCasesWithDatedDocument("digitalGrant", date);
+        ImmutableList.Builder<ReturnedCaseDetails> filteredCases = ImmutableList.builder();
+
+        for (ReturnedCaseDetails returnedCase : cases) {
+            if (returnedCase.getData().getScannedDocuments() != null) {
+                for (CollectionMember<ScannedDocument> document : returnedCase.getData().getScannedDocuments()) {
+                    if (document.getValue().getSubtype().equals(DOC_SUBTYPE_WILL)) {
+                        filteredCases.add(returnedCase);
+                    }
+                }
+            }
+        }
+
+        if (!filteredCases.build().isEmpty()) {
+            for (ReturnedCaseDetails excelaCase : filteredCases.build()) {
+                notificationService.sendExcelaEmail(excelaCase);
+            }
+        }
+
+        return ResponseEntity.ok(filteredCases.build().size() + " cases found and emailed for date: " + date);
+    }
+
+    private void dateValidator(String date) {
+        try {
+            LocalDate.parse(date, DATE_FORMAT);
+        } catch (DateTimeParseException e) {
+            log.error("Error parsing date, use the format of 'yyyy-MM-dd': ");
+            throw new ClientException(HttpStatus.BAD_REQUEST.value(),
+                    "Error parsing date, use the format of 'yyyy-MM-dd': " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/ReturnedCaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/ReturnedCaseDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.probate.model.ccd.raw.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class ReturnedCaseDetails {
+
+    @Valid
+    @JsonProperty(value = "case_data")
+    private final CaseData data;
+
+    private final String[] lastModified;
+
+    @NotNull
+    private final Long id;
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/ReturnedCases.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/ReturnedCases.java
@@ -2,11 +2,12 @@ package uk.gov.hmcts.probate.model.ccd.raw.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+
 import java.util.List;
 
 @Data
 public class ReturnedCases {
 
     @JsonProperty(value = "cases")
-    private final List<CaseDetails> cases;
+    private final List<ReturnedCaseDetails> cases;
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseQueryService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseQueryService.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.probate.config.CCDDataStoreAPIConfiguration;
 import uk.gov.hmcts.probate.exception.CaseMatchingException;
 import uk.gov.hmcts.probate.insights.AppInsights;
 import uk.gov.hmcts.probate.model.CaseType;
-import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCases;
 import uk.gov.hmcts.probate.service.evidencemanagement.header.HttpHeadersFactory;
 
@@ -42,7 +42,7 @@ public class CaseQueryService {
     private final HttpHeadersFactory headers;
     private final CCDDataStoreAPIConfiguration ccdDataStoreAPIConfiguration;
 
-    public List<CaseDetails> findCasesWithDatedDocument(String documentTypeGenerated, String queryDate) {
+    public List<ReturnedCaseDetails> findCasesWithDatedDocument(String documentTypeGenerated, String queryDate) {
         BoolQueryBuilder query = boolQuery();
 
         query.must(matchQuery(STATE, STATE_MATCH));
@@ -54,8 +54,8 @@ public class CaseQueryService {
         return runQuery(jsonQuery);
     }
 
-    public List<CaseDetails> findCaseStateWithinTimeFrame(String documentTypeGenerated,
-                                                          String startDate, String endDate) {
+    public List<ReturnedCaseDetails> findCaseStateWithinTimeFrame(String documentTypeGenerated,
+                                                                  String startDate, String endDate) {
         BoolQueryBuilder query = boolQuery();
 
         query.must(matchQuery(STATE, STATE_MATCH));
@@ -67,7 +67,7 @@ public class CaseQueryService {
         return runQuery(jsonQuery);
     }
 
-    private List<CaseDetails> runQuery(String jsonQuery) {
+    private List<ReturnedCaseDetails> runQuery(String jsonQuery) {
         log.info("GrantMatchingService runQuery: " + jsonQuery);
         URI uri = UriComponentsBuilder
                 .fromHttpUrl(ccdDataStoreAPIConfiguration.getHost() + ccdDataStoreAPIConfiguration.getCaseMatchingPath())

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.Document;
 import uk.gov.hmcts.probate.model.ccd.raw.ScannedDocument;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -87,7 +88,7 @@ public class NotificationService {
         return getGeneratedSentEmailDocument(response, emailAddress);
     }
 
-    public Document sendExcelaEmail(CaseDetails caseDetails) throws
+    public Document sendExcelaEmail(ReturnedCaseDetails caseDetails) throws
             NotificationClientException {
         String templateId = notificationTemplates.getEmail().get(caseDetails.getData().getApplicationType())
                 .getExcelaData();

--- a/src/main/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileService.java
@@ -8,7 +8,7 @@ import uk.gov.hmcts.probate.model.ApplicationType;
 import uk.gov.hmcts.probate.model.ccd.raw.Grantee;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
-import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class IronMountainFileService {
     private final TextFileBuilderService textFileBuilderService;
     private static final String DELIMITER = "|";
 
-    public File createIronMountainFile(CaseDetails ccdCase, String fileName) throws IOException {
+    public File createIronMountainFile(ReturnedCaseDetails ccdCase, String fileName) throws IOException {
         return textFileBuilderService.createFile(prepareData(ccdCase.getId(), ccdCase.getData()), DELIMITER, fileName);
     }
 

--- a/src/test/java/uk/gov/hmcts/probate/controller/DataExtractControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/DataExtractControllerTest.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.probate.controller;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.gov.hmcts.probate.insights.AppInsights;
+import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
+import uk.gov.hmcts.probate.model.ccd.raw.DocumentLink;
+import uk.gov.hmcts.probate.model.ccd.raw.ScannedDocument;
+import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
+import uk.gov.hmcts.probate.service.CaseQueryService;
+import uk.gov.hmcts.probate.service.NotificationService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class DataExtractControllerTest {
+
+    private static final String[] LAST_MODIFIED = {"2018", "1", "1", "0", "0", "0", "0"};
+
+    @MockBean
+    private CaseQueryService caseQueryService;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private AppInsights appInsights;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Before
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        CollectionMember<ScannedDocument> scannedDocument = new CollectionMember<>(new ScannedDocument("1",
+                "test", "other", "will", LocalDateTime.now(), DocumentLink.builder().build(),
+                "test"));
+        List<CollectionMember<ScannedDocument>> scannedDocuments = new ArrayList<>();
+        scannedDocuments.add(scannedDocument);
+
+        CaseData caseData = CaseData.builder()
+                .deceasedSurname("smith")
+                .scannedDocuments(scannedDocuments)
+                .build();
+        List<ReturnedCaseDetails> returnedCases = new ImmutableList.Builder<ReturnedCaseDetails>().add(new
+                ReturnedCaseDetails(caseData, LAST_MODIFIED, 1L)).build();
+
+        when(caseQueryService.findCasesWithDatedDocument(any(), any())).thenReturn(returnedCases);
+    }
+
+    @Test
+    public void ironMountainShouldReturnOkResponseOnValidDateFormat() throws Exception {
+        mockMvc.perform(post("/data-extract/iron-mountain/2019-03-13"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1 cases successfully found for date: 2019-03-13"));
+    }
+
+    @Test
+    public void ironMountainShouldReturnOkWithYesterdayDateOnEmptyPathParam() throws Exception {
+        mockMvc.perform(post("/data-extract/iron-mountain"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1 cases successfully found for date: " + DATE_FORMAT.format(LocalDate
+                        .now().minusDays(1L))));
+    }
+
+    @Test
+    public void shouldThrowClientExceptionWithBadRequestForIronMountainWithIncorrectDateFormat() throws Exception {
+        mockMvc.perform(post("/data-extract/iron-mountain/2019-2-3"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void excelaShouldReturnOkResponseOnValidDateFormat() throws Exception {
+        mockMvc.perform(post("/data-extract/excela/2019-02-13"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1 cases found and emailed for date: 2019-02-13"));
+    }
+
+    @Test
+    public void excelaShouldReturnOkWithYesterdayDateOnEmptyPathParam() throws Exception {
+        mockMvc.perform(post("/data-extract/excela"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1 cases found and emailed for date: " + DATE_FORMAT.format(LocalDate
+                        .now().minusDays(1L))));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseQueryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseQueryServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.probate.config.CCDDataStoreAPIConfiguration;
 import uk.gov.hmcts.probate.exception.CaseMatchingException;
 import uk.gov.hmcts.probate.insights.AppInsights;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
-import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCases;
 import uk.gov.hmcts.probate.service.evidencemanagement.header.HttpHeadersFactory;
 
@@ -61,7 +61,7 @@ public class CaseQueryServiceTest {
         CaseData caseData = CaseData.builder()
                 .deceasedSurname("Smith")
                 .build();
-        List<CaseDetails> caseList = new ImmutableList.Builder<CaseDetails>().add(new CaseDetails(caseData,
+        List<ReturnedCaseDetails> caseList = new ImmutableList.Builder<ReturnedCaseDetails>().add(new ReturnedCaseDetails(caseData,
                 LAST_MODIFIED, 1L))
                 .build();
         ReturnedCases returnedCases = new ReturnedCases(caseList);
@@ -73,7 +73,7 @@ public class CaseQueryServiceTest {
 
     @Test
     public void findCasesWithDatedDocumentReturnsCaseList() throws IOException {
-        List<CaseDetails> cases = caseQueryService.findCasesWithDatedDocument("Test",
+        List<ReturnedCaseDetails> cases = caseQueryService.findCasesWithDatedDocument("Test",
                 "testDate");
 
         assertEquals(1, cases.size());
@@ -83,7 +83,7 @@ public class CaseQueryServiceTest {
 
     @Test
     public void findCasesWithDateRangeReturnsCaseList() {
-        List<CaseDetails> cases = caseQueryService.findCaseStateWithinTimeFrame("digitalGrant",
+        List<ReturnedCaseDetails> cases = caseQueryService.findCaseStateWithinTimeFrame("digitalGrant",
                 "2019-02-05", "2019-02-22");
 
         assertEquals(1, cases.size());

--- a/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.ScannedDocument;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.service.notify.NotificationClient;
@@ -72,7 +73,7 @@ public class NotificationServiceTest {
     private CaseDetails personalCaseDataManchester;
     private CaseDetails personalCaseDataCtsc;
     private CaseDetails solicitorCaseDataManchester;
-    private CaseDetails excelaCaseData;
+    private ReturnedCaseDetails excelaCaseData;
 
     private CaveatDetails personalCaveatDataOxford;
     private CaveatDetails personalCaveatDataBirmingham;
@@ -153,7 +154,7 @@ public class NotificationServiceTest {
                 .deceasedDateOfDeath(LocalDate.of(2000, 12, 12))
                 .build(), LAST_MODIFIED, ID);
 
-        excelaCaseData = new CaseDetails(CaseData.builder()
+        excelaCaseData = new ReturnedCaseDetails(CaseData.builder()
                 .applicationType(PERSONAL)
                 .deceasedSurname("Michelson")
                 .scannedDocuments(scannedDocuments)

--- a/src/test/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.Document;
 import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
+import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.util.FileUtils;
 
 import java.io.BufferedReader;
@@ -30,7 +31,7 @@ public class IronMountainFileServiceTest {
 
     private IronMountainFileService ironmountainFileService = new IronMountainFileService(new TextFileBuilderService());
     private CaseData.CaseDataBuilder caseData;
-    private CaseDetails createdCase;
+    private ReturnedCaseDetails createdCase;
     private CaseData builtData;
     private static final String FILE_NAME = "testFile.txt";
     private static final String[] LAST_MODIFIED = {"2018", "1", "1", "0", "0", "0", "0"};
@@ -73,7 +74,7 @@ public class IronMountainFileServiceTest {
     @Test
     public void testIronMountainFileBuilt() throws IOException {
         builtData = caseData.build();
-        createdCase = new CaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
+        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         assertThat(createFile(ironmountainFileService.createIronMountainFile(createdCase, FILE_NAME)).readLine(),
                 is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFilePopulated.txt")));
     }
@@ -93,7 +94,7 @@ public class IronMountainFileServiceTest {
                 .primaryApplicantAddress(SolsAddress.builder().build())
                 .additionalExecutorsApplying(additionalExecutors);
         builtData = caseData.build();
-        createdCase = new CaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
+        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         assertThat(createFile(ironmountainFileService.createIronMountainFile(createdCase, FILE_NAME)).readLine(),
                 is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFileEmptyOptionals.txt")));
     }
@@ -102,7 +103,7 @@ public class IronMountainFileServiceTest {
     public void testPrimaryApplicantAsNoChangesGrantee() throws IOException {
         caseData.primaryApplicantIsApplying("No");
         builtData = caseData.build();
-        createdCase = new CaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
+        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         assertThat(createFile(ironmountainFileService.createIronMountainFile(createdCase, FILE_NAME)).readLine(),
                 is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainPrimaryApplicantNo.txt")));
     }
@@ -111,7 +112,7 @@ public class IronMountainFileServiceTest {
     public void testSolicitorApplicationTypeDisplaysSolicitorInformation() throws IOException {
         caseData.applicationType(ApplicationType.SOLICITOR);
         builtData = caseData.build();
-        createdCase = new CaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
+        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         assertThat(createFile(ironmountainFileService.createIronMountainFile(createdCase, FILE_NAME)).readLine(),
                 is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainSolicitor.txt")));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-4668

### Change description ###

Created 2 endpoints for Iron mountain, one that takes in a date as a path param which is then used to search for cases against, currently the story to provide functionality for this is yet to be played so the return of this is simply the cases found - to soon be file generated and sent via FTP, the second IM endpoint takes no path param and instead is the default which will generate for yesterdays date, this is duplicated for excela too where the cases returned are filtered for scanned doc and then emailed to excela. Also created new request model ReturnedCaseDetails that can fit the serialization of case details from ES query

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
