### PR TITLE
PRO-5051 Legacy import of estate values 

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/probateman/mapper/GrantApplicationMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/probateman/mapper/GrantApplicationMapper.java
@@ -44,8 +44,8 @@ public interface GrantApplicationMapper extends ProbateManMapper<GrantApplicatio
 
     @Mapping(target = "additionalExecutorsApplying", source = "grantApplication",
             qualifiedBy = {ToAdditionalExecutorApplyingMember.class})
-    @Mapping(target = "ihtNetValue", source = "netEstateValue")
-    @Mapping(target = "ihtGrossValue", source = "grossEstateValue")
+    @Mapping(target = "ihtNetValue", expression = "java(grantApplication.getNetEstateValue() * 100)")
+    @Mapping(target = "ihtGrossValue", expression = "java(grantApplication.getGrossEstateValue() * 100)")
     @Mapping(target = "recordId", source = "probateNumber")
     @Mapping(target = "legacyId", source = "id")
     @Mapping(target = "legacyType", expression = "java(LegacyCaseType.GRANT_OF_REPRESENTATION.getName())")

--- a/src/test/java/uk/gov/hmcts/probate/service/probateman/mapper/GrantApplicationMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/probateman/mapper/GrantApplicationMapperTest.java
@@ -40,7 +40,9 @@ public class GrantApplicationMapperTest {
     private static final LocalDate DATE_OF_DEATH = LocalDate.of(2018, 1, 1);
     private static final String DECEASED_ADDRESS = "DecAddL1, DeacAddPC";
     private static final Long GROSS_ESTATE = 10000L;
+    private static final Long GROSS_ESTATE_TRANSFORMED = 1000000L;
     private static final Long NET_ESTATE = 9000L;
+    private static final Long NET_ESTATE_TRANSFORMED = 900000L;
     private static final String SOLICITOR_REFERENCE = "SolRef1";
 
     @Autowired
@@ -98,8 +100,8 @@ public class GrantApplicationMapperTest {
         assertThat(grantApplicationData.getDeceasedDateOfBirth()).isEqualTo(DATE_OF_BIRTH);
         assertThat(grantApplicationData.getDeceasedDateOfDeath()).isEqualTo(DATE_OF_DEATH);
         assertThat(grantApplicationData.getDeceasedAddress()).isEqualToComparingFieldByFieldRecursively(expectedDeceasedAddress);
-        assertThat(grantApplicationData.getIhtGrossValue()).isEqualTo(GROSS_ESTATE);
-        assertThat(grantApplicationData.getIhtNetValue()).isEqualTo(NET_ESTATE);
+        assertThat(grantApplicationData.getIhtGrossValue()).isEqualTo(GROSS_ESTATE_TRANSFORMED);
+        assertThat(grantApplicationData.getIhtNetValue()).isEqualTo(NET_ESTATE_TRANSFORMED);
         assertThat(grantApplicationData.getGrantType()).isEqualTo(GrantType.GRANT_OF_PROBATE);
         assertThat(grantApplicationData.getLegacyId()).isEqualTo(ID);
         assertThat(grantApplicationData.getLegacyType()).isEqualTo(LEGACY_TYPE);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5051


### Change description ###
ProbateMan stored estate value is whole pounds, where as CCD stores with pence, therefore conversion was not happening correctly


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
