### PR TITLE
PRO-5043 Set solicitor fields when app type is null 

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -423,7 +423,7 @@ public class CallbackResponseTransformer {
             }
         }
 
-        if (caseData.getApplicationType() == ApplicationType.SOLICITOR) {
+        if (caseData.getApplicationType() != ApplicationType.PERSONAL) {
             builder
                     .solsSOTName(caseData.getSolsSOTName())
                     .solsSOTJobTitle(caseData.getSolsSOTJobTitle())
@@ -486,7 +486,7 @@ public class CallbackResponseTransformer {
                 .ihtReferenceNumber(caseData.getIhtReferenceNumber())
                 .solsDeceasedAliasNamesList(caseData.getSolsDeceasedAliasNamesList());
 
-        if (caseData.getApplicationType() == ApplicationType.SOLICITOR) {
+        if (caseData.getApplicationType() != ApplicationType.PERSONAL) {
             builder
                     .solsSOTName(caseData.getSolsSOTName())
                     .solsSOTJobTitle(caseData.getSolsSOTJobTitle())
@@ -496,8 +496,6 @@ public class CallbackResponseTransformer {
                     .solsSolicitorPhoneNumber(caseData.getSolsSolicitorPhoneNumber())
                     .solsSolicitorAddress(caseData.getSolsSolicitorAddress());
         }
-
-
 
         if (!isPaperForm(caseData)) {
             builder

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -1073,6 +1073,17 @@ public class CallbackResponseTransformerTest {
     }
 
     @Test
+    public void shouldSetSolicitorsInfoWhenApplicationTypeIsNull() {
+        caseDataBuilder.applicationType(null);
+
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+
+        CallbackResponse callbackResponse = underTest.paperForm(callbackRequestMock);
+        assertSolsDetails(callbackResponse);
+    }
+
+    @Test
     public void shouldSetGrantIssuedDate() {
         caseDataBuilder.applicationType(ApplicationType.PERSONAL);
         Document document = Document.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5043


### Change description ###
Change logic to build sols fields only when app type does not equal personal. Because the beginning of the sols journey the app type is not defined


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
