### PR TITLE
BUG FIX: 5606- added filter to ES query to make sure cases that have not been paid are not matched against

### DIFF
--- a/src/main/resources/templates/elasticsearch/caseMatching/main_query.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/main_query.json
@@ -1,6 +1,11 @@
 {
   "query": {
     "bool": {
+      "must_not": {
+        "match": {
+          "state": "PAAppCreated"
+        }
+      },
       "should": [
         {
           "bool": {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5605

### Change description ###
added filter for ES query to not include cases that are in state PAAppCreated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
