### PR TITLE
PRO-6183: corrected case stopped sols email wording

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,7 +170,7 @@ notifications:
         requestInformation: "8fd291a1-67a7-48fa-a051-fa4c93315efc"
       solicitor:
         documentReceived: "7f8ff32d-8297-4702-9867-312047f81492"
-        caseStopped: "77041301-77a5-4382-a3a7-0bada17518b0"
+        caseStopped: "350f488a-68f1-44f0-b083-157285b71581"
         caseStoppedCaveat: "937291a0-c0ae-40a4-a8cf-46a3452faff0"
         grantIssued: "95aa541b-e55e-4d7c-a6f5-810b5f03adba"
         grantReissued: "1e18751f-fd4e-4893-85bb-f59cc5330c38"


### PR DESCRIPTION
Changed email wording for SOLs case stopped

When pushing to live, please move the OLD notify template to the archive folder (77041301-77a5-4382-a3a7-0bada17518b0) Case stopped (solicitor)
And rename the new one (350f488a-68f1-44f0-b083-157285b71581) Case stopped (solicitor) AAT to
Case stopped (solicitor)
```
[ ] Yes
[X ] No
```
