### PR TITLE
PRO-6241 PA digital cases primaryApplicantIsApplying is not set

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/ExecutorsApplyingNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/ExecutorsApplyingNotificationService.java
@@ -51,7 +51,7 @@ public class ExecutorsApplyingNotificationService {
     }
 
     private void addPrimaryApplicant(CaseData caseData) {
-        if (YES.equals(caseData.getPrimaryApplicantIsApplying())) {
+        if (YES.equals(caseData.getPrimaryApplicantIsApplying()) || caseData.getPrimaryApplicantIsApplying() == null) {
             executorList.add(buildExecutorList(caseData.getPrimaryApplicantFullName(),
                     caseData.getPrimaryApplicantEmailAddress(), caseData.getPrimaryApplicantAddress()));
         }

--- a/src/test/java/uk/gov/hmcts/probate/service/ExecutorsApplyingNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ExecutorsApplyingNotificationServiceTest.java
@@ -108,6 +108,62 @@ public class ExecutorsApplyingNotificationServiceTest {
     }
 
     @Test
+    public void testPaApplyingIsNull() {
+        caseDataPersonal = CaseData.builder()
+                .applicationType(ApplicationType.PERSONAL)
+                .primaryApplicantForenames("Bob")
+                .primaryApplicantSurname("Smith")
+                .primaryApplicantEmailAddress("PA@test.com")
+                .primaryApplicantAddress(ADDRESS)
+                .primaryApplicantIsApplying(null)
+                .additionalExecutorsApplying(null)
+                .build();
+
+        CollectionMember<ExecutorsApplyingNotification> execApplying =
+                buildExecNotification("Bob Smith", "PA@test.com", "1");
+        expectedResponse.add(execApplying);
+
+        assertEquals(expectedResponse, executorsApplyingNotificationService.createExecutorList(caseDataPersonal));
+        assertEquals(expectedResponse.size(), 1);
+    }
+
+    @Test
+    public void testPaApplyingIsNotApplying() {
+        caseDataPersonal = CaseData.builder()
+                .applicationType(ApplicationType.PERSONAL)
+                .primaryApplicantForenames("Bob")
+                .primaryApplicantSurname("Smith")
+                .primaryApplicantEmailAddress("PA@test.com")
+                .primaryApplicantAddress(ADDRESS)
+                .primaryApplicantIsApplying("No")
+                .additionalExecutorsApplying(null)
+                .build();
+
+        assertEquals(expectedResponse, executorsApplyingNotificationService.createExecutorList(caseDataPersonal));
+        assertEquals(expectedResponse.size(), 0);
+    }
+
+    @Test
+    public void testPaIsApplying() {
+        caseDataPersonal = CaseData.builder()
+                .applicationType(ApplicationType.PERSONAL)
+                .primaryApplicantForenames("Bob")
+                .primaryApplicantSurname("Smith")
+                .primaryApplicantEmailAddress("PA@test.com")
+                .primaryApplicantAddress(ADDRESS)
+                .primaryApplicantIsApplying("Yes")
+                .additionalExecutorsApplying(null)
+                .build();
+
+        CollectionMember<ExecutorsApplyingNotification> execApplying =
+                buildExecNotification("Bob Smith", "PA@test.com", "1");
+        expectedResponse.add(execApplying);
+
+        assertEquals(expectedResponse, executorsApplyingNotificationService.createExecutorList(caseDataPersonal));
+        assertEquals(expectedResponse.size(), 1);
+    }
+
+    @Test
     public void testMultipleExecutorsAreAddedSuccessfully() {
         additionalExecutorApplyingList.add(buildExecApplying("Tommy Tank", "tommy@test.com"));
         additionalExecutorApplyingList.add(buildExecApplying("Bobby Bank", "bobby@test.com"));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6241


### Change description ###
PA Digital cases do not have primary applicant set, therefore its is assumed that all cases that are not set are digital cases


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
