### PR TITLE
Replace pound with decimal unicode encoding

### DIFF
--- a/src/main/resources/templates/pdf/admonWillGrant.html
+++ b/src/main/resources/templates/pdf/admonWillGrant.html
@@ -298,8 +298,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/admonWillGrantDraft.html
+++ b/src/main/resources/templates/pdf/admonWillGrantDraft.html
@@ -302,8 +302,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/digitalGrant.html
+++ b/src/main/resources/templates/pdf/digitalGrant.html
@@ -316,8 +316,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/digitalGrantDraft.html
+++ b/src/main/resources/templates/pdf/digitalGrantDraft.html
@@ -320,8 +320,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/intestacyGrant.html
+++ b/src/main/resources/templates/pdf/intestacyGrant.html
@@ -295,8 +295,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/intestacyGrantDraft.html
+++ b/src/main/resources/templates/pdf/intestacyGrantDraft.html
@@ -299,8 +299,8 @@
 
             </p>
             <p>The application has stated that the gross value of the estate in {% if case_details.case_data.domicilityCountry != null and case_details.case_data.domicilityCountry != "" %}England and Wales{% else %}the United Kingdom{% endif %} amounts to
-                £{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
-                £{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
+                &#163;{{(case_details.case_data.ihtGrossValue / 100) | numberformat("###,###.##")}} and the net value amounts to
+                &#163;{{(case_details.case_data.ihtNetValue / 100) | numberformat("###,###.##")}}
             </p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/legalStatementAdmon.html
+++ b/src/main/resources/templates/pdf/legalStatementAdmon.html
@@ -127,7 +127,7 @@
     </tr>
     <tr>
         <td colspan="2">
-            <p>The gross value for the estate amounts to £{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to £{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
+            <p>The gross value for the estate amounts to &#163;{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to &#163;{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
             <p>To the best of my knowledge, information and belief, there was no land vested in {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} which was settled previously to the death (and not by the will) of {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} and which remained settled land notwithstanding such death.</p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/legalStatementIntestacy.html
+++ b/src/main/resources/templates/pdf/legalStatementIntestacy.html
@@ -141,7 +141,7 @@
     </tr>
     <tr>
         <td colspan="2">
-            <p>The gross value for the estate amounts to £{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to £{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
+            <p>The gross value for the estate amounts to &#163;{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to &#163;{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
             <p>To the best of my knowledge, information and belief, there was no land vested in {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} which was settled previously to the death of {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} and which remained settled land notwithstanding such death.</p>
         </td>
     </tr>

--- a/src/main/resources/templates/pdf/legalStatementProbate.html
+++ b/src/main/resources/templates/pdf/legalStatementProbate.html
@@ -136,7 +136,7 @@
     </tr>
     <tr>
         <td colspan="2">
-            <p>The gross value for the estate amounts to £{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to £{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
+            <p>The gross value for the estate amounts to &#163;{{ (case_details.case_data.ihtGrossValue/100)|numberformat("#.00") }} and the net value for the estate amounts to &#163;{{ (case_details.case_data.ihtNetValue/100)|numberformat("#.00") }}.</p>
             <p>To the best of our knowledge, information and belief, there was no land vested in {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} which was settled previously to the death (and not by the will) of {{ case_details.case_data.deceasedForenames }} {{ case_details.case_data.deceasedSurname }} and which remained settled land notwithstanding such death.</p>
         </td>
     </tr>

--- a/src/main/resources/templates/printService/caseDetailsPA.html
+++ b/src/main/resources/templates/printService/caseDetailsPA.html
@@ -2,7 +2,7 @@
 <html lang="en">
 {% macro names(forenames, surname) %}{{ forenames }} {{ surname }}{% endmacro %}
 {% macro notApplyingReason(reason) %}{% if reason == "DiedBefore" %}They died before the deceased.{% endif %}{% if reason == "DiedAfter"%}They died after the deceased.{% endif %}{% if reason == "PowerReserved" %}They're holding power reserved.{% endif%}{% if reason == "Renunciation" %}They have renounced.{% endif %}{% endmacro %}
-{% macro replaceAllEncoded(original) %}{{ original | replace('&rsquo;', '’')  | replace('&pound;', '£') }}{% endmacro %}
+{% macro replaceAllEncoded(original) %}{{ original | replace('&rsquo;', '’')  | replace('&pound;', '&#163;') }}{% endmacro %}
 <head>
   <title>Application for probate for {{ names(case_data.deceasedForenames,case_data.deceasedSurname) }}</title>
 </head>
@@ -132,11 +132,11 @@
   </tr>
   <tr>
     <td colspan="2">IHT Gross value:</td>
-    <td>{% if case_data.ihtGrossValue %}£{{ (case_data.ihtGrossValue/100) | money('0,0.00') }}{% endif %}</td>
+    <td>{% if case_data.ihtGrossValue %}&#163;{{ (case_data.ihtGrossValue/100) | money('0,0.00') }}{% endif %}</td>
   </tr>
   <tr>
     <td colspan="2">IHT Net value:</td>
-    <td>{% if case_data.ihtNetValue %}£{{ (case_data.ihtNetValue/100) | money('0,0.00') }}{% endif %}</td>
+    <td>{% if case_data.ihtNetValue %}&#163;{{ (case_data.ihtNetValue/100) | money('0,0.00') }}{% endif %}</td>
   </tr>
   <tr>
     <td colspan="2">Payment reference:</td>
@@ -210,7 +210,7 @@
   </tr>
   <tr>
     <td colspan="2">Total fee due:</td>
-    <td>{% if case_data.totalFee %}£{{ (case_data.totalFee/100) | money('0,0.00') }}{% endif %}</td>
+    <td>{% if case_data.totalFee %}&#163;{{ (case_data.totalFee/100) | money('0,0.00') }}{% endif %}</td>
   </tr>
   <tr>
     <td colspan="2">Assets in an alias name:</td>


### PR DESCRIPTION
Potentially safer fix than:
https://github.com/hmcts/probate-back-office/pull/730

Functional test proving this works is here:
https://github.com/hmcts/rpe-pdf-service/pull/125
(test with just £ fails on docker image, but with `&#163;` it passes