### PR TITLE
PRO-6311: Default value to no in callback transformer

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -656,11 +656,13 @@ public class CallbackResponseTransformer {
         if (isSolsEmailSet(caseData)) {
             builder
                     .boEmailDocsReceivedNotification(ANSWER_YES)
-                    .boEmailRequestInfoNotification(ANSWER_YES);
+                    .boEmailRequestInfoNotification(ANSWER_YES)
+                    .boEmailGrantIssuedNotification(ANSWER_YES);
         } else {
             builder
                     .boEmailDocsReceivedNotification(ANSWER_NO)
-                    .boEmailRequestInfoNotification(ANSWER_NO);
+                    .boEmailRequestInfoNotification(ANSWER_NO)
+                    .boEmailGrantIssuedNotification(ANSWER_NO);
         }
 
         if (!isCodicil(caseData)) {
@@ -751,11 +753,13 @@ public class CallbackResponseTransformer {
         if (isSolsEmailSet(caseData)) {
             builder
                     .boEmailDocsReceivedNotification(ANSWER_YES)
-                    .boEmailRequestInfoNotification(ANSWER_YES);
+                    .boEmailRequestInfoNotification(ANSWER_YES)
+                    .boEmailGrantIssuedNotification(ANSWER_YES);
         } else {
             builder
                     .boEmailDocsReceivedNotification(ANSWER_NO)
-                    .boEmailRequestInfoNotification(ANSWER_NO);
+                    .boEmailRequestInfoNotification(ANSWER_NO)
+                    .boEmailGrantIssuedNotification(ANSWER_NO);
         }
 
         if (!isCodicil(caseData)) {

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -1012,6 +1012,20 @@ public class CallbackResponseTransformerTest {
         assertEquals(IHT_REFERENCE, callbackResponse.getData().getIhtReferenceNumber());
     }
 
+
+    @Test
+    public void shouldTransformCaseForSolsEmailEmpty() {
+        caseDataBuilder.solsSolicitorEmail("");
+
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+
+        assertEquals(NO, callbackResponse.getData().getBoEmailGrantIssuedNotification());
+    }
+
+
     @Test
     public void shouldTransformCaseForPAWithPrimaryApplicantAlias() {
         caseDataBuilder.primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-6311

### Change description ###

SOLs case without SOLs email does not default to No for Issue Grant notif

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
