### PR TITLE
PRO-6389 BUGFIX:  additional applying exec data lost 

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/AdditionalExecutorApplying.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/AdditionalExecutorApplying.java
@@ -8,6 +8,8 @@ import lombok.Data;
 public class AdditionalExecutorApplying {
 
     private final String applyingExecutorName;
+    private final String applyingExecutorFirstName;
+    private final String applyingExecutorLastName;
     private final String applyingExecutorPhoneNumber;
     private final String applyingExecutorEmail;
     private final SolsAddress applyingExecutorAddress;

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -1698,6 +1698,35 @@ public class CallbackResponseTransformerTest {
         underTest.addSOTDocument(callbackRequestMock, SOT_DOC);
     }
 
+    @Test
+    public void shouldTransformAdditionalExecApplyingName() {
+        List<CollectionMember<AdditionalExecutorApplying>> additionalExecsAppList = new ArrayList<>();
+        additionalExecsAppList.add(createAdditionalExecutorApplying("0"));
+        caseDataBuilder.additionalExecutorsApplying(additionalExecsAppList);
+
+
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+        assertEquals(EXEC_FIRST_NAME + " " + EXEC_SURNAME,
+                callbackResponse.getData().getAdditionalExecutorsApplying().get(0).getValue().getApplyingExecutorName());
+    }
+
+    @Test
+    public void shouldNotTransformAdditionalExecApplyingName() {
+        List<CollectionMember<AdditionalExecutorApplying>> additionalExecsAppList = new ArrayList<>();
+        additionalExecsAppList.add(createAdditionalExecutorApplyingfNamelName("0"));
+        caseDataBuilder.additionalExecutorsApplying(additionalExecsAppList);
+
+
+        when(callbackRequestMock.getCaseDetails()).thenReturn(caseDetailsMock);
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock);
+        assertEquals(EXEC_FIRST_NAME + " " + EXEC_SURNAME,
+                callbackResponse.getData().getAdditionalExecutorsApplying().get(0).getValue().getApplyingExecutorName());
+
+    }
+
     private CollectionMember<ProbateAliasName> createdDeceasedAliasName(String id, String forename, String lastname, String onGrant) {
         ProbateAliasName pan = ProbateAliasName.builder()
                 .appearOnGrant(onGrant)
@@ -1774,6 +1803,20 @@ public class CallbackResponseTransformerTest {
                 .applyingExecutorAddress(EXEC_ADDRESS)
                 .applyingExecutorEmail(EXEC_EMAIL)
                 .applyingExecutorName(EXEC_FIRST_NAME + " " + EXEC_SURNAME)
+                .applyingExecutorOtherNames(ALIAS_FORENAME + " " + ALIAS_SURNAME)
+                .applyingExecutorPhoneNumber(EXEC_PHONE)
+                .applyingExecutorOtherNamesReason("Other")
+                .applyingExecutorOtherReason("Married")
+                .build();
+        return new CollectionMember<>(id, add1na);
+    }
+
+    private CollectionMember<AdditionalExecutorApplying> createAdditionalExecutorApplyingfNamelName(String id) {
+        AdditionalExecutorApplying add1na = AdditionalExecutorApplying.builder()
+                .applyingExecutorAddress(EXEC_ADDRESS)
+                .applyingExecutorEmail(EXEC_EMAIL)
+                .applyingExecutorFirstName(EXEC_FIRST_NAME)
+                .applyingExecutorLastName(EXEC_SURNAME)
                 .applyingExecutorOtherNames(ALIAS_FORENAME + " " + ALIAS_SURNAME)
                 .applyingExecutorPhoneNumber(EXEC_PHONE)
                 .applyingExecutorOtherNamesReason("Other")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6389


### Change description ###
If user enters applyingExecutorFirstName and applyingExecutorLastName data is lost, it should be mapped too applyingExecutorName


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
