### PR TITLE
Pro 6813 set relative booleans for ages over zero

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
@@ -42,6 +42,7 @@ import uk.gov.hmcts.reform.probate.model.cases.grantofrepresentation.GrantType;
                 OCRFieldNumberMapper.class
         },
         unmappedTargetPolicy = ReportingPolicy.IGNORE, nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+@SuppressWarnings("Duplicates")
 public interface ExceptionRecordGrantOfRepresentationMapper {
     @Mapping(target = "extraCopiesOfGrant", source = "ocrFields.extraCopiesOfGrant", qualifiedBy = {ToLong.class})
     @Mapping(target = "outsideUkGrantCopies", source = "ocrFields.outsideUKGrantCopies", qualifiedBy = {ToLong.class})


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6813


### Change description ###
Relatives of the deceased booleans e.g. parentsExistSurvived which are derived from values like parentsExistUnderEighteenSurvived and parentsExistOverEighteenSurvived should only be set if the boolean will end up as true I.e. parentsExistOverEighteenSurvived or parentsExistUnderEighteenSurvived has a value over 0. Currently the code defaults these values to false which could be confusing to the business.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
