### PR TITLE
PRO-6817: Correction to supress duplicate lines - false positive.

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
@@ -42,7 +42,6 @@ import uk.gov.hmcts.reform.probate.model.cases.grantofrepresentation.GrantType;
                 OCRFieldNumberMapper.class
         },
         unmappedTargetPolicy = ReportingPolicy.IGNORE, nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
-@SuppressWarnings("Duplicates")
 public interface ExceptionRecordGrantOfRepresentationMapper {
     @Mapping(target = "extraCopiesOfGrant", source = "ocrFields.extraCopiesOfGrant", qualifiedBy = {ToLong.class})
     @Mapping(target = "outsideUkGrantCopies", source = "ocrFields.outsideUKGrantCopies", qualifiedBy = {ToLong.class})
@@ -194,6 +193,7 @@ public interface ExceptionRecordGrantOfRepresentationMapper {
     }
 
     @AfterMapping
+    @SuppressWarnings("Duplicates")
     default void setDerivedFamilyIntestacyBooleans(
             @MappingTarget GrantOfRepresentationData caseData, ExceptionRecordOCRFields ocrField, GrantType grantType) {
         if (grantType.equals(GrantType.INTESTACY)) {

--- a/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/ExceptionRecordGrantOfRepresentationMapper.java
@@ -94,62 +94,34 @@ public interface ExceptionRecordGrantOfRepresentationMapper {
     @Mapping(target = "grandChildrenSurvivedOverEighteenText", expression = "java(ocrFields.getGrandChildrenSurvivedOverEighteen())")
 
     // Ignored fields defined in after mapping section.
-    @Mapping(target = "parentsExistSurvived", ignore = true)
     @Mapping(target = "parentsExistUnderEighteenSurvived", source = "ocrFields.parentsExistUnderEighteenSurvived")
     @Mapping(target = "parentsExistOverEighteenSurvived", source = "ocrFields.parentsExistOverEighteenSurvived")
-
-    @Mapping(target = "wholeBloodSiblingsSurvived", ignore = true)
     @Mapping(target = "wholeBloodSiblingsSurvivedUnderEighteen", source = "ocrFields.wholeBloodSiblingsSurvivedUnderEighteen")
     @Mapping(target = "wholeBloodSiblingsSurvivedOverEighteen", source = "ocrFields.wholeBloodSiblingsSurvivedOverEighteen")
-
-    @Mapping(target = "wholeBloodSiblingsDied", ignore = true)
     @Mapping(target = "wholeBloodSiblingsDiedUnderEighteen", source = "ocrFields.wholeBloodSiblingsDiedUnderEighteen")
     @Mapping(target = "wholeBloodSiblingsDiedOverEighteen", source = "ocrFields.wholeBloodSiblingsDiedOverEighteen")
-
-    @Mapping(target = "wholeBloodNeicesAndNephews", ignore = true)
     @Mapping(target = "wholeBloodNeicesAndNephewsUnderEighteen", source = "ocrFields.wholeBloodNeicesAndNephewsUnderEighteen")
     @Mapping(target = "wholeBloodNeicesAndNephewsOverEighteen", source = "ocrFields.wholeBloodNeicesAndNephewsOverEighteen")
-
-    @Mapping(target = "halfBloodSiblingsSurvived", ignore = true)
     @Mapping(target = "halfBloodSiblingsSurvivedUnderEighteen", source = "ocrFields.halfBloodSiblingsSurvivedUnderEighteen")
     @Mapping(target = "halfBloodSiblingsSurvivedOverEighteen", source = "ocrFields.halfBloodSiblingsSurvivedOverEighteen")
-
-    @Mapping(target = "halfBloodSiblingsDied", ignore = true)
     @Mapping(target = "halfBloodSiblingsDiedUnderEighteen", source = "ocrFields.halfBloodSiblingsDiedUnderEighteen")
     @Mapping(target = "halfBloodSiblingsDiedOverEighteen", source = "ocrFields.halfBloodSiblingsDiedOverEighteen")
-
-    @Mapping(target = "halfBloodNeicesAndNephews", ignore = true)
     @Mapping(target = "halfBloodNeicesAndNephewsUnderEighteen", source = "ocrFields.halfBloodNeicesAndNephewsUnderEighteen")
     @Mapping(target = "halfBloodNeicesAndNephewsOverEighteen", source = "ocrFields.halfBloodNeicesAndNephewsOverEighteen")
-
-    @Mapping(target = "grandparentsDied", ignore = true)
     @Mapping(target = "grandparentsDiedUnderEighteen", source = "ocrFields.grandparentsDiedUnderEighteen")
     @Mapping(target = "grandparentsDiedOverEighteen", source = "ocrFields.grandparentsDiedOverEighteen")
-
-    @Mapping(target = "wholeBloodUnclesAndAuntsSurvived", ignore = true)
     @Mapping(target = "wholeBloodUnclesAndAuntsSurvivedUnderEighteen", source = "ocrFields.wholeBloodUnclesAndAuntsSurvivedUnderEighteen")
     @Mapping(target = "wholeBloodUnclesAndAuntsSurvivedOverEighteen", source = "ocrFields.wholeBloodUnclesAndAuntsSurvivedOverEighteen")
-
-    @Mapping(target = "wholeBloodUnclesAndAuntsDied", ignore = true)
     @Mapping(target = "wholeBloodUnclesAndAuntsDiedUnderEighteen", source = "ocrFields.wholeBloodUnclesAndAuntsDiedUnderEighteen")
     @Mapping(target = "wholeBloodUnclesAndAuntsDiedOverEighteen", source = "ocrFields.wholeBloodUnclesAndAuntsDiedOverEighteen")
-
-    @Mapping(target = "wholeBloodCousinsSurvived", ignore = true)
     @Mapping(target = "wholeBloodCousinsSurvivedUnderEighteen", source = "ocrFields.wholeBloodCousinsSurvivedUnderEighteen")
     @Mapping(target = "wholeBloodCousinsSurvivedOverEighteen", source = "ocrFields.wholeBloodCousinsSurvivedOverEighteen")
-
-    @Mapping(target = "halfBloodUnclesAndAuntsSurvived", ignore = true)
     @Mapping(target = "halfBloodUnclesAndAuntsSurvivedUnderEighteen", source = "ocrFields.halfBloodUnclesAndAuntsSurvivedUnderEighteen")
     @Mapping(target = "halfBloodUnclesAndAuntsSurvivedOverEighteen", source = "ocrFields.halfBloodUnclesAndAuntsSurvivedOverEighteen")
-
-    @Mapping(target = "halfBloodUnclesAndAuntsDied", ignore = true)
     @Mapping(target = "halfBloodUnclesAndAuntsDiedUnderEighteen", source = "ocrFields.halfBloodUnclesAndAuntsDiedUnderEighteen")
     @Mapping(target = "halfBloodUnclesAndAuntsDiedOverEighteen", source = "ocrFields.halfBloodUnclesAndAuntsDiedOverEighteen")
-
-    @Mapping(target = "halfBloodCousinsSurvived", ignore = true)
     @Mapping(target = "halfBloodCousinsSurvivedUnderEighteen", source = "ocrFields.halfBloodCousinsSurvivedUnderEighteen")
     @Mapping(target = "halfBloodCousinsSurvivedOverEighteen", source = "ocrFields.halfBloodCousinsSurvivedOverEighteen")
-
     @Mapping(target = "primaryApplicantRelationshipToDeceased",
             source = "ocrFields.primaryApplicantRelationshipToDeceased", qualifiedBy = {ToRelationship.class})
     @Mapping(target = "paRelationshipToDeceasedOther",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6813


### Change description ###
Relatives of the deceased booleans e.g. parentsExistSurvived which are derived from values like parentsExistUnderEighteenSurvived and parentsExistOverEighteenSurvived should only be set if the boolean will end up as true I.e. parentsExistOverEighteenSurvived or parentsExistUnderEighteenSurvived has a value over 0. Currently the code defaults these values to false which could be confusing to the business.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
