### PR TITLE
Pro 6847 update to fix error message for money conversion

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldIhtMoneyMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldIhtMoneyMapper.java
@@ -22,18 +22,18 @@ public class OCRFieldIhtMoneyMapper {
     private static final String FORM_IHT400 = "IHT400";
 
     @ToPennies
-    public Long poundsToPennies(String monetaryValue) {
+    public Long poundsToPennies(final String monetaryValue) {
         log.info("Beginning mapping for monetary value: {}", monetaryValue);
         Long returnValue;
 
         if (monetaryValue == null || monetaryValue.isEmpty()) {
             return null;
         } else {
-            monetaryValue = monetaryValue.replaceAll("[^\\d^\\.]","");
+            String numericalMonetaryValue = monetaryValue.replaceAll("[^\\d^\\.]","");
             try {
-                returnValue = new BigDecimal(monetaryValue).multiply(ONE_HUNDRED).longValue();
+                returnValue = new BigDecimal(numericalMonetaryValue).multiply(ONE_HUNDRED).longValue();
             } catch (Exception e) {
-                String errorMessage = "Monetary field '" + monetaryValue + "' could not be mapped to a case: " + e.getMessage();
+                String errorMessage = "Monetary field '" + monetaryValue + "' could not be converted to a number";
                 log.error(errorMessage);
                 throw new OCRMappingException(errorMessage);
             }

--- a/src/test/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldIhtMoneyMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldIhtMoneyMapperTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.probate.service.exceptionrecord.mapper;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import uk.gov.hmcts.probate.exception.OCRMappingException;
 import uk.gov.hmcts.reform.probate.model.IhtFormType;
 
@@ -21,14 +23,19 @@ public class OCRFieldIhtMoneyMapperTest {
     private static final String IHT400_FORM = "IHT400";
     private static final String UNKNOWN_FORM = "UNKOWNFORM";
 
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
     @Test
     public void testPoundsToPennies() {
         Long response = ocrFieldIhtMoneyMapper.poundsToPennies(MONETARY_TEST_VALUE_INPUT);
         assertEquals(MONETARY_TEST_VALUE_PENNIES, response);
     }
 
-    @Test(expected = OCRMappingException.class)
-    public void testExceptionForToPenniesNotNumeric() {
+    @Test
+    public void testExceptionForToPenniesNotNumeric() throws Exception {
+        expectedEx.expect(OCRMappingException.class);
+        expectedEx.expectMessage("Monetary field '" + MONETARY_TEST_UNKNOWN_VALUE + "' could not be converted to a number");
         Long response = ocrFieldIhtMoneyMapper.poundsToPennies(MONETARY_TEST_UNKNOWN_VALUE);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6847


### Change description ###
Very simple correction to error message for invalid monetary values in OCR data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
