### PR TITLE
PRO-6961: corrected multi name execs

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -681,7 +681,7 @@ public class CaseData {
     }
 
     private List<String> splitFullname(String fullName) {
-        return Arrays.asList(fullName.split(" "));
+        return new ArrayList(Arrays.asList(fullName.split(" ")));
     }
 
     private boolean isApplying(CollectionMember<AdditionalExecutor> ex, boolean applying) {

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
@@ -347,7 +347,7 @@ public class CaseDataTest {
 
     @Test
     public void shouldSplitApplyingExecutorNameWhenDoubleBarrelledNames() {
-        when(additionalExecutorApplying1Mock.getApplyingExecutorName()).thenReturn("Appl-ying Name");
+        when(additionalExecutorApplying1Mock.getApplyingExecutorName()).thenReturn("John James Michael Smith");
         when(additionalExecutorApplying2Mock.getApplyingExecutorName()).thenReturn("Applying Na-me");
         when(additionalExecutorApplying3Mock.getApplyingExecutorName()).thenReturn("Appl-ying Na-me");
 
@@ -365,8 +365,8 @@ public class CaseDataTest {
         List<CollectionMember<AdditionalExecutor>> applying = caseData.getExecutorsApplyingForLegalStatement();
 
         assertEquals(4, applying.size());
-        assertEquals("Appl-ying", applying.get(1).getValue().getAdditionalExecForenames());
-        assertEquals("Name", applying.get(1).getValue().getAdditionalExecLastname());
+        assertEquals("John James Michael", applying.get(1).getValue().getAdditionalExecForenames());
+        assertEquals("Smith", applying.get(1).getValue().getAdditionalExecLastname());
         assertEquals("Applying", applying.get(2).getValue().getAdditionalExecForenames());
         assertEquals("Na-me", applying.get(2).getValue().getAdditionalExecLastname());
         assertEquals("Appl-ying", applying.get(3).getValue().getAdditionalExecForenames());


### PR DESCRIPTION
Corrected use of larger than 2 names for additional execs, used during grant issue