### PR TITLE
Pro 7010 add postcode mapping bsp phase2

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldAddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldAddressMapper.java
@@ -111,6 +111,7 @@ public class OCRFieldAddressMapper {
         if (StringUtils.isBlank(address.getPostCode())) {
             return null;
         } else {
+            address.setPostCode(postCode.toUpperCase());
             validatePostCode(address.getPostCode());
         }
         return address;

--- a/src/test/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldAddressMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/exceptionrecord/mapper/OCRFieldAddressMapperTest.java
@@ -24,7 +24,7 @@ public class OCRFieldAddressMapperTest {
     private static final String ADDRESS_LINE2 = "22 Green Park";
     private static final String ADDRESS_POST_TOWN = "London";
     private static final String ADDRESS_COUNTY = "Greater London";
-    private static final String ADDRESS_POST_CODE = "NW1 1AB";
+    private static final String ADDRESS_POST_CODE = "nW1 1Ab";
     private static final String ADDRESS_POST_CODE_ERROR = "NW1";
 
     private static final String ADDRESS_POST_CODE_CORRECT_ERROR_MESSAGE =
@@ -100,7 +100,7 @@ public class OCRFieldAddressMapperTest {
         assertEquals(ADDRESS_LINE2, response.getAddressLine2());
         assertEquals(ADDRESS_POST_TOWN, response.getPostTown());
         assertEquals(ADDRESS_COUNTY, response.getCounty());
-        assertEquals(ADDRESS_POST_CODE, response.getPostCode());
+        assertEquals(ADDRESS_POST_CODE.toUpperCase(), response.getPostCode());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class OCRFieldAddressMapperTest {
         assertEquals(ADDRESS_LINE2, response.getAddressLine2());
         assertEquals(ADDRESS_POST_TOWN, response.getPostTown());
         assertEquals(ADDRESS_COUNTY, response.getCounty());
-        assertEquals(ADDRESS_POST_CODE, response.getPostCode());
+        assertEquals(ADDRESS_POST_CODE.toUpperCase(), response.getPostCode());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class OCRFieldAddressMapperTest {
         assertEquals(ADDRESS_LINE2, response.getAddressLine2());
         assertEquals(ADDRESS_POST_TOWN, response.getPostTown());
         assertEquals(ADDRESS_COUNTY, response.getCounty());
-        assertEquals(ADDRESS_POST_CODE, response.getPostCode());
+        assertEquals(ADDRESS_POST_CODE.toUpperCase(), response.getPostCode());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class OCRFieldAddressMapperTest {
         assertEquals(ADDRESS_LINE2, response.get(0).getValue().getAddress().getAddressLine2());
         assertEquals(ADDRESS_POST_TOWN, response.get(0).getValue().getAddress().getPostTown());
         assertEquals(ADDRESS_COUNTY, response.get(0).getValue().getAddress().getCounty());
-        assertEquals(ADDRESS_POST_CODE, response.get(0).getValue().getAddress().getPostCode());
+        assertEquals(ADDRESS_POST_CODE.toUpperCase(), response.get(0).getValue().getAddress().getPostCode());
     }
 
     @Test(expected = OCRMappingException.class)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-7010


### Change description ###
Added postcode validation for cases created through bulk scan. This is invoked when attempting to create a case with an invalid UK postcode.

Also amended martial status error message to provide valid values if an invalid martial status was provided - technically this shouldn't happen as the value should be provided from exela based off a checkbox being checked but it's consisted now with the other valid value error messages.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
