### PR TITLE
Pro 6812 update to remove 404 bulk scanning

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/controller/ExceptionRecordController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/ExceptionRecordController.java
@@ -63,8 +63,7 @@ public class ExceptionRecordController {
     @ApiResponses({
             @ApiResponse(code = 200, response = ValidationResponse.class, message = "Validation executed successfully"),
             @ApiResponse(code = 400, message = "Request failed due to malformed syntax"),
-            @ApiResponse(code = 403, message = "S2S token is not authorized, missing or invalid"),
-            @ApiResponse(code = 404, message = "Form type not found")
+            @ApiResponse(code = 403, message = "S2S token is not authorized, missing or invalid")
     })
     @PostMapping(path = "/transform-exception-record",
             consumes = APPLICATION_JSON_UTF8_VALUE, produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/hmcts/probate/controller/OCRFormsController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/OCRFormsController.java
@@ -59,13 +59,4 @@ public class OCRFormsController {
                         .status(warnings.isEmpty() ? ValidationResponseStatus.SUCCESS : ValidationResponseStatus.WARNINGS).build();
         return ResponseEntity.ok(validationResponse);
     }
-
-    @ExceptionHandler(OCRMappingException.class)
-    public ResponseEntity<ValidationResponse> handle(OCRMappingException exception) {
-        log.error("An error has occured during the bulk scanning OCR validation process: {}", exception.getMessage(), exception);
-        List<String> errors = Arrays.asList(exception.getMessage());
-        ValidationResponse validationResponse =
-                ValidationResponse.builder().status(ValidationResponseStatus.ERRORS).errors(errors).build();
-        return ResponseEntity.ok(validationResponse);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
@@ -13,11 +13,16 @@ import uk.gov.hmcts.probate.exception.BusinessValidationException;
 import uk.gov.hmcts.probate.exception.ClientException;
 import uk.gov.hmcts.probate.exception.ConnectionException;
 import uk.gov.hmcts.probate.exception.NotFoundException;
+import uk.gov.hmcts.probate.exception.OCRMappingException;
 import uk.gov.hmcts.probate.exception.model.ErrorResponse;
+import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
+import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponseStatus;
 import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
 import uk.gov.service.notify.NotificationClientException;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -92,4 +97,14 @@ class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new ResponseEntity<>(errorResponse, headers, NOT_FOUND);
     }
+
+    @ExceptionHandler(OCRMappingException.class)
+    public ResponseEntity<ValidationResponse> handle(OCRMappingException exception) {
+        log.error("An error has occured during the bulk scanning OCR validation process: {}", exception.getMessage(), exception);
+        List<String> errors = Arrays.asList(exception.getMessage());
+        ValidationResponse validationResponse =
+            ValidationResponse.builder().status(ValidationResponseStatus.ERRORS).errors(errors).build();
+        return ResponseEntity.ok(validationResponse);
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/probate/model/exceptionrecord/ExceptionRecordErrorResponse.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/exceptionrecord/ExceptionRecordErrorResponse.java
@@ -14,6 +14,11 @@ public class ExceptionRecordErrorResponse {
     @JsonProperty("errors")
     public final List<String> errors;
 
+    public ExceptionRecordErrorResponse(List<String> errors) {
+        this.errors = errors;
+        this.warnings = null;
+    }
+
     public ExceptionRecordErrorResponse(List<String> errors, List<String> warnings) {
         this.errors = errors;
         this.warnings = warnings;

--- a/src/main/java/uk/gov/hmcts/probate/service/ocr/FormType.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/ocr/FormType.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.probate.service.ocr;
 
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.probate.exception.NotFoundException;
+import uk.gov.hmcts.probate.exception.OCRMappingException;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+@Slf4j
 public enum FormType {
     PA1P,
     PA1A,
@@ -12,7 +15,8 @@ public enum FormType {
 
     public static void isFormTypeValid(String formType) {
         if (Arrays.stream(FormType.values()).noneMatch(type -> type.name().equals(formType))) {
-            throw new NotFoundException("Form type '" + formType + "' not found");
+            log.error("Form type '{}' not found", formType);
+            throw new OCRMappingException("Form type not found or invalid");
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/controller/ExceptionRecordControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/ExceptionRecordControllerTest.java
@@ -141,8 +141,8 @@ public class ExceptionRecordControllerTest {
         mockMvc.perform(post("/transform-exception-record")
                 .content(modifiedExceptionRecordPayload.toString())
                 .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is4xxClientError())
-                .andExpect(content().string(containsString("Form type 'null' not found")));
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Form type not found or invalid")));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/controller/OCRFormsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/OCRFormsControllerTest.java
@@ -111,11 +111,11 @@ public class OCRFormsControllerTest {
     }
 
     @Test
-    public void testInvalidFormTypeThrowsNotFound() throws Exception {
+    public void testInvalidFormTypeReturnsError() throws Exception {
         mockMvc.perform(post("/forms/test/validate-ocr")
                 .content(ocrPayload)
                 .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().is4xxClientError())
-                .andExpect(content().string(containsString("Form type 'test' not found")));
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Form type not found or invalid")));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
@@ -10,8 +10,10 @@ import uk.gov.hmcts.probate.exception.BusinessValidationException;
 import uk.gov.hmcts.probate.exception.ClientException;
 import uk.gov.hmcts.probate.exception.ConnectionException;
 import uk.gov.hmcts.probate.exception.NotFoundException;
+import uk.gov.hmcts.probate.exception.OCRMappingException;
 import uk.gov.hmcts.probate.exception.model.ErrorResponse;
 import uk.gov.hmcts.probate.exception.model.FieldErrorResponse;
+import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
 import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -46,6 +48,9 @@ public class DefaultExceptionHandlerTest {
 
     @Mock
     private NotFoundException notFoundException;
+
+    @Mock
+    private OCRMappingException ocrMappingException;
 
     @InjectMocks
     private DefaultExceptionHandler underTest;
@@ -133,5 +138,16 @@ public class DefaultExceptionHandlerTest {
         assertEquals(NOT_FOUND, response.getStatusCode());
         assertEquals(DefaultExceptionHandler.CLIENT_ERROR, response.getBody().getError());
         assertEquals(EXCEPTION_MESSAGE, response.getBody().getMessage());
+    }
+    
+    @Test
+    public void shouldReturnOCRMappingException() {
+        when(ocrMappingException.getMessage()).thenReturn(EXCEPTION_MESSAGE);
+
+        ResponseEntity<ValidationResponse> response = underTest.handle(ocrMappingException);
+
+        assertEquals(OK, response.getStatusCode());
+        assertEquals(1, response.getBody().getErrors().size());
+        assertEquals("Message", response.getBody().getErrors().get(0));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6812


### Change description ###
Updated to remove HTTP 404 response if an incorrect form-type is provided for an OCR validation. The correct response according to the new specification is to provide a HTTP 200 with a JSON error of "Form type not found or invalid".

https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1064666568


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
