### PR TITLE
DTSPB-526: Add comma between deceased fn and deceased ln

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/notification/GrantOfRepresentationPersonalisationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/notification/GrantOfRepresentationPersonalisationService.java
@@ -96,7 +96,7 @@ public class GrantOfRepresentationPersonalisationService {
             data.append(getWillReferenceNumber(currentCase.getData()));
             data.append(", ");
             data.append(currentCase.getData().getDeceasedForenames());
-            data.append(" ");
+            data.append(", ");
             data.append(currentCase.getData().getDeceasedSurname());
             data.append(", ");
             data.append(EXCELA_CONTENT_DATE.format(currentCase.getData().getDeceasedDateOfBirth()));

--- a/src/test/java/uk/gov/hmcts/probate/service/notification/GrantOfRepresentationPersonalisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/notification/GrantOfRepresentationPersonalisationServiceTest.java
@@ -208,7 +208,7 @@ public class GrantOfRepresentationPersonalisationServiceTest {
                 grantOfRepresentationPersonalisationService.getExcelaPersonalisation(excelaCaseData);
 
         assertEquals(LocalDateTime.now().format(EXCELA_DATE) + "will", response.get(PERSONALISATION_EXCELA_NAME));
-        assertEquals("123456, Jack Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
+        assertEquals("123456, Jack, Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
     }
 
     @Test
@@ -217,7 +217,7 @@ public class GrantOfRepresentationPersonalisationServiceTest {
                 grantOfRepresentationPersonalisationService.getExcelaPersonalisation(excelaCaseDataNoWillReference);
 
         assertEquals(LocalDateTime.now().format(EXCELA_DATE) + "will", response.get(PERSONALISATION_EXCELA_NAME));
-        assertEquals(", Jack Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
+        assertEquals(", Jack, Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
     }
 
 
@@ -227,7 +227,7 @@ public class GrantOfRepresentationPersonalisationServiceTest {
                 grantOfRepresentationPersonalisationService.getExcelaPersonalisation(excelaCaseDataNoSubtype);
 
         assertEquals(LocalDateTime.now().format(EXCELA_DATE) + "will", response.get(PERSONALISATION_EXCELA_NAME));
-        assertEquals(", Jack Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
+        assertEquals(", Jack, Michelson, 01/01/2019, 01/05/2019, 1\n", response.get(PERSONALISATION_CASE_DATA));
     }
 
     @Test


### PR DESCRIPTION
JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-526

### Change description ###

Split deceased names in excela email

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
