### PR TITLE
strip \r from text before comparing in tests

### DIFF
--- a/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
@@ -79,7 +79,8 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBody.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -89,7 +90,8 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithNoWill.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -98,9 +100,11 @@ public class ConfirmationResponseServiceFeatureTest {
         CCDData ccdData = createCCDataBuilder().executors(Collections.singletonList(renouncingExecutor)).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithRenouncingExecutor.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithRenouncingExecutor.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -110,9 +114,11 @@ public class ConfirmationResponseServiceFeatureTest {
         CCDData ccdData = createCCDataBuilder().executors(Arrays.asList(renouncingExecutor, renouncingExecutor2)).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleRenouncingExecutors.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleRenouncingExecutors.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -123,7 +129,8 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithDeadExecutor.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -133,9 +140,11 @@ public class ConfirmationResponseServiceFeatureTest {
         CCDData ccdData = createCCDataBuilder().executors(Arrays.asList(deadExecutor, deadExecutor2)).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleDeadExecutors.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleDeadExecutors.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -143,9 +152,11 @@ public class ConfirmationResponseServiceFeatureTest {
         CCDData ccdData = createCCDataBuilder().iht(createInheritanceTax("IHT400421")).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithIHT400421.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithIHT400421.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -157,9 +168,11 @@ public class ConfirmationResponseServiceFeatureTest {
                 .iht(createInheritanceTax("IHT400421")).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinations.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinations.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -173,9 +186,11 @@ public class ConfirmationResponseServiceFeatureTest {
                 .iht(createInheritanceTax("IHT400421")).build();
         AfterSubmitCallbackResponse stopConfirmation = confirmationResponseService.getNextStepsConfirmation(ccdData);
 
-        String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinationsAndMultiples.md");
+        String expectedConfirmationBody =
+                testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinationsAndMultiples.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -185,7 +200,8 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyCaveat.md");
 
-        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()),
+                is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     private CCDData.CCDDataBuilder createCCDataBuilder() {

--- a/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ConfirmationResponseServiceFeatureTest.java
@@ -79,7 +79,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBody.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithNoWill.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithRenouncingExecutor.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleRenouncingExecutors.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithDeadExecutor.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithMultipleDeadExecutors.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -145,7 +145,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithIHT400421.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -159,7 +159,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinations.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyWithAllCombinationsAndMultiples.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     @Test
@@ -185,7 +185,7 @@ public class ConfirmationResponseServiceFeatureTest {
 
         String expectedConfirmationBody = testUtils.getStringFromFile("expectedConfirmationBodyCaveat.md");
 
-        assertThat(stopConfirmation.getConfirmationBody(), is(expectedConfirmationBody));
+        assertThat(testUtils.stripSuperfluousChars(stopConfirmation.getConfirmationBody()), is(testUtils.stripSuperfluousChars(expectedConfirmationBody)));
     }
 
     private CCDData.CCDDataBuilder createCCDataBuilder() {

--- a/src/test/java/uk/gov/hmcts/probate/service/filebuilder/HmrcFileServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/filebuilder/HmrcFileServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.util.FileUtils;
+import uk.gov.hmcts.probate.util.TestUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.when;
 public class HmrcFileServiceTest {
     private FileExtractDateFormatter fileExtractDateFormatter = Mockito.mock(FileExtractDateFormatter.class);
     private HmrcFileService hmrcFileService = new HmrcFileService(new TextFileBuilderService(), fileExtractDateFormatter);
+    private final TestUtils testUtils = new uk.gov.hmcts.probate.util.TestUtils();
 
     private ImmutableList.Builder<ReturnedCaseDetails> caseList = new ImmutableList.Builder<>();
     private CaseData.CaseDataBuilder caseDataSolictor;
@@ -194,8 +197,10 @@ public class HmrcFileServiceTest {
         builtData = caseDataSolictor.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1111222233334444L);
         caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcSolicitor.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcSolicitor.txt"))));
     }
 
     @Test
@@ -204,7 +209,8 @@ public class HmrcFileServiceTest {
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 2222333344445555L);
         caseList.add(createdCase);
         assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonal.txt")));
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonal.txt"))));
     }
 
     @Test
@@ -215,8 +221,10 @@ public class HmrcFileServiceTest {
 
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 2222333344445555L);
         caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalZeroIHTs.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalZeroIHTs.txt"))));
     }
 
     @Test
@@ -225,8 +233,10 @@ public class HmrcFileServiceTest {
         caseList.add(new ReturnedCaseDetails(builtData, LAST_MODIFIED, 2222333344445555L));
         builtData = caseDataSolictor.build();
         caseList.add(new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1111222233334444L));
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcMultipleCases.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcMultipleCases.txt"))));
     }
 
     @Test
@@ -244,8 +254,10 @@ public class HmrcFileServiceTest {
         builtData = caseDataSolictor.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 3333444455556666L);
         caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcEmptyOptionals.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcEmptyOptionals.txt"))));
     }
 
     @Test
@@ -254,17 +266,10 @@ public class HmrcFileServiceTest {
         builtData = caseDataPersonal.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 4444555566667777L);
         caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPrimaryApplicantNo.txt")));
-    }
-
-    @Test
-    public void testCarriageReturnInAddressIsReplacedWithSpace() throws IOException {
-        builtData = caseDataCarriageReturns.build();
-        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 5555666677778888L);
-        caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalReplaced.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPrimaryApplicantNo.txt"))));
     }
 
     @Test
@@ -272,8 +277,21 @@ public class HmrcFileServiceTest {
         builtData = caseDataMissingData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 5555666677778888L);
         caseList.add(createdCase);
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalMissingAddresses.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                    createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalMissingAddresses.txt"))));
+    }
+
+    @Test
+    public void testCarriageReturnInAddressIsReplacedWithSpace() throws IOException {
+        builtData = caseDataCarriageReturns.build();
+        createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 5555666677778888L);
+        caseList.add(createdCase);
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalReplaced.txt"))));
     }
 
     @Test
@@ -284,8 +302,9 @@ public class HmrcFileServiceTest {
         caseList.add(createdCase);
         String expected = FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalMissingIHT.txt");
         
-        assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(expected));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(expected)));
     }
 
     @Test
@@ -297,7 +316,7 @@ public class HmrcFileServiceTest {
         String expected = FileUtils.getStringFromFile("expectedGeneratedFiles/hmrcPersonalMissingCase.txt");
 
         assertThat(createFile(hmrcFileService.createHmrcFile(caseList.build(), FILE_NAME)),
-            is(expected));
+            is(testUtils.stripSuperfluousChars(expected)));
     }
     
     private String createFile(File file) throws IOException {

--- a/src/test/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.SolsAddress;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.util.FileUtils;
+import uk.gov.hmcts.probate.util.TestUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertThat;
 
 public class IronMountainFileServiceTest {
 
+    private final TestUtils testUtils = new TestUtils();
     private IronMountainFileService ironmountainFileService = new IronMountainFileService(new TextFileBuilderService());
     private ImmutableList.Builder<ReturnedCaseDetails> caseList = new ImmutableList.Builder<>();
     private CaseData.CaseDataBuilder caseData;
@@ -100,8 +102,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFilePopulated.txt")));
+        assertThat(testUtils.stripSuperfluousChars(createFile(
+                ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                        FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFilePopulated.txt"))));
     }
 
     @Test
@@ -111,8 +115,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFilePopulatedZeroIHTs.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFilePopulatedZeroIHTs.txt"))));
     }
 
     @Test
@@ -132,8 +138,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFileEmptyOptionals.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFileEmptyOptionals.txt"))));
     }
 
     @Test
@@ -142,8 +150,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainPrimaryApplicantNo.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+            createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainPrimaryApplicantNo.txt"))));
     }
 
     @Test
@@ -152,8 +162,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainSolicitor.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                        FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainSolicitor.txt"))));
     }
 
     @Test
@@ -161,8 +173,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData2.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainOneAddressLine.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                        FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainOneAddressLine.txt"))));
     }
 
     @Test
@@ -171,8 +185,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFileCtsc.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                        FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainFileCtsc.txt"))));
     }
 
     @Test
@@ -183,8 +199,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-                is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainSolAsPrimary.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+                is(testUtils.stripSuperfluousChars(
+                        FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainSolAsPrimary.txt"))));
     }
 
     @Test
@@ -193,8 +211,10 @@ public class IronMountainFileServiceTest {
         builtData = caseData2.build();
         createdCase = new ReturnedCaseDetails(builtData, LAST_MODIFIED, 1234567890876L);
         caseList.add(createdCase);
-        assertThat(createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME)),
-            is(FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainExceptionCase.txt")));
+        assertThat(testUtils.stripSuperfluousChars(
+                createFile(ironmountainFileService.createIronMountainFile(caseList.build(), FILE_NAME))),
+            is(testUtils.stripSuperfluousChars(
+                    FileUtils.getStringFromFile("expectedGeneratedFiles/ironMountainExceptionCase.txt"))));
     }
 
     private String createFile(File file) throws IOException {

--- a/src/test/java/uk/gov/hmcts/probate/util/TestUtils.java
+++ b/src/test/java/uk/gov/hmcts/probate/util/TestUtils.java
@@ -15,4 +15,11 @@ public class TestUtils {
 
         return new String(Files.readAllBytes(file.toPath()));
     }
+
+    public String stripSuperfluousChars(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        return text.replaceAll("\r", "");
+    }
 }


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPB-732 ###

### Change description ###
Strip \r within testcode for both expected and actual output, in order for tests to run successfully on Windows as well as Linux/Mac os.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
