### PR TITLE
Dtspb 1566 solicitor not executor bug

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformer.java
@@ -212,7 +212,7 @@ public class ExecutorsTransformer {
             List<CollectionMember<AdditionalExecutorNotApplying>> execsNotApplying, CaseData caseData) {
 
         // Transform list
-        if (NO.equals(caseData.getSolsSolicitorIsExec()) || NO.equals(caseData.getSolsSolicitorIsApplying())) {
+        if (isSolicitorExecutor(caseData) && NO.equals(caseData.getSolsSolicitorIsApplying())) {
 
             // Add solicitor to not applying list
             execsNotApplying = executorListMapperService.addSolicitorToNotApplyingList(caseData, execsNotApplying);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
@@ -408,22 +408,21 @@ public class ExecutorsTransformerTest {
     }
 
     @Test
-    public void shouldSetCaseworkerNotApplyingWithSolicitorInfo_NotExec() {
+    public void caseworkerNotApplyingListShouldBeEmpty_NotExec() {
         caseDataBuilder
                 .solsSolicitorIsExec(NO);
 
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
-        when(executorListMapperServiceMock.addSolicitorToNotApplyingList(
-                caseDetailsMock.getData(), new ArrayList<>())).thenReturn(additionalExecutorNotApplying);
 
         solicitorExecutorTransformerMock.mapSolicitorExecutorFieldsToCaseworkerExecutorFields(
                 caseDetailsMock.getData(), responseCaseDataBuilder);
 
         ResponseCaseData responseCaseData = responseCaseDataBuilder.build();
-        assertEquals(additionalExecutorNotApplying, responseCaseData.getAdditionalExecutorsNotApplying());
-        verify(executorListMapperServiceMock, times(1))
+        assertTrue(responseCaseData.getAdditionalExecutorsNotApplying().isEmpty());
+        verify(executorListMapperServiceMock, times(0))
                 .addSolicitorToNotApplyingList(any(), any());
     }
+    
 
     @Test
     public void shouldRemoveSolicitorInfoFromCaseworkerNotApplying_IsApplying() {
@@ -630,7 +629,7 @@ public class ExecutorsTransformerTest {
     @Test
     public void shouldSetExecutorNamesList_SolicitorNotApplying() {
         caseDataBuilder
-                .solsSolicitorIsExec(NO)
+                .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
                 .solsSOTForenames(SOLICITOR_SOT_FORENAME)
                 .solsSOTSurname(SOLICITOR_SOT_SURNAME)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-1566

### Change description ###

Fix bug where a solicitor who is not an executor is appearing in an executor applying list. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
