### PR TITLE
DTSPB-1930 - trust corps - duplicate sol exec bug

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
@@ -148,6 +148,7 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
     private static final String BRISTOL_GOP_PAYLOAD = "solicitorPayloadNotificationsGopBristol.json";
     private static final String TRUST_CORPS_GOP_PAYLOAD = "solicitorPayloadTrustCorpsTransformed.json";
     private static final String GENERATE_LETTER_PAYLOAD = "/document/generateLetter.json";
+    private static final String NO_DUPE_SOL_EXECUTORS = "solicitorPayloadLegalStatementNoDuplicateExecsCheck.json";
 
     @Test
     public void verifySolicitorGenerateGrantShouldReturnOkResponseCode() {
@@ -1311,7 +1312,9 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
     public void verifySoTFourthParagraphAllSuccessorPartnersRenouncingClearingFive() {
         String response = generatePdfDocument("solicitorPayLoadSuccessorFirmAllRenounce.json",
                 GENERATE_LEGAL_STATEMENT);
-        assertTrue(response.contains("Probate Practioner, an executor named in the will, is applying for probate."));
+        // all partners are renouncing, so other partners in the collection are ignored, and wording is
+        // 'the executor named in the will' as opposed to 'an executor named in the will'
+        assertTrue(response.contains("Probate Practioner, the executor named in the will, is applying for probate."));
 
     }
 
@@ -1319,7 +1322,9 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
     public void verifySoTFourthParagraphAllPartnerFirmsRenouncingClearingSix() {
         String response = generatePdfDocument("solicitorPayloadPartnersAllRenounce.json",
                 GENERATE_LEGAL_STATEMENT);
-        assertTrue(response.contains("Probate Practioner, an executor named in the will, is applying for probate."));
+        // all partners are renouncing, so other partners in the collection are ignored, and wording is
+        // 'the executor named in the will' as opposed to 'an executor named in the will'
+        assertTrue(response.contains("Probate Practioner, the executor named in the will, is applying for probate."));
 
     }
 
@@ -1419,5 +1424,13 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
                 + " with this application, in which Exfn1 Exln1 identified by the position they hold and which"
                 + " is still in force, appointed them for the purpose of applying for probate of "
                 + "the will or for grants of probate on its behalf."));
+    }
+
+    @Test
+    public void verifySoTNoDuplicateSolExecutors() {
+        String response = generatePdfDocument(NO_DUPE_SOL_EXECUTORS, GENERATE_LEGAL_STATEMENT);
+        assertTrue(response.contains("The executor believes that all the information stated in the legal statement is true."));
+        assertTrue(response.contains("Fred Smith, the executor named in the will or codicil, is applying for probate"));
+        assertTrue(response.split("Fred Smith").length == 5);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
@@ -1429,7 +1429,8 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
     @Test
     public void verifySoTNoDuplicateSolExecutors() {
         String response = generatePdfDocument(NO_DUPE_SOL_EXECUTORS, GENERATE_LEGAL_STATEMENT);
-        assertTrue(response.contains("The executor believes that all the information stated in the legal statement is true."));
+        assertTrue(response
+                .contains("The executor believes that all the information stated in the legal statement is true."));
         assertTrue(response.contains("Fred Smith, the executor named in the will or codicil, is applying for probate"));
         assertTrue(response.split("Fred Smith").length == 5);
     }

--- a/src/functionalTest/resources/json/solicitorPayloadLegalStatementNoDuplicateExecsCheck.json
+++ b/src/functionalTest/resources/json/solicitorPayloadLegalStatementNoDuplicateExecsCheck.json
@@ -1,0 +1,203 @@
+{
+  "case_details": {
+    "id": 1528365719153338,
+    "jurisdiction": "PROBATE",
+    "state": "CaseCreated",
+    "case_type_id": "GrantOfRepresentation",
+    "created_date": [
+      2018,
+      6,
+      7,
+      10,
+      1,
+      59,
+      151000000
+    ],
+    "last_modified": [
+      2018,
+      6,
+      7,
+      10,
+      8,
+      8,
+      695000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "iht217": "Yes",
+      "caseType": "gop",
+      "taskList": "",
+      "totalFee": "15500",
+      "ihtFormId": "IHT205",
+      "paperForm": "No",
+      "willExists": "Yes",
+      "appointExec": "Yes",
+      "bulkPrintId": [],
+      "caseMatches": [],
+      "casePrinted": "Yes",
+      "englishWill": "Yes",
+      "ihtNetValue": "19000000",
+      "solsSOTName": "Fred Smith",
+      "willDispose": "Yes",
+      "solsWillType": "WillLeft",
+      "ihtGrossValue": "20500000",
+      "schemaVersion": "2.0.0",
+      "applicationFee": "15500",
+      "feeForUkCopies": "0",
+      "solsSOTSurname": "Smith",
+      "applicationType": "Solicitor",
+      "dateOfDeathType": "diedOn",
+      "deceasedAddress": {
+        "County": "Wilts",
+        "Country": "United Kingdom",
+        "PostCode": "Sn2 2JU",
+        "PostTown": "Swindon",
+        "AddressLine1": "1 High St",
+        "AddressLine2": null,
+        "AddressLine3": null
+      },
+      "deceasedSurname": "Jones",
+      "willHasCodicils": "Yes",
+      "paragraphDetails": [],
+      "registryLocation": "ctsc",
+      "solsSOTForenames": "Fred",
+      "boSendToBulkPrint": "Yes",
+      "bulkScanEnvelopes": [],
+      "deceasedForenames": "Terry",
+      "executorsApplying": [],
+      "feeForNonUkCopies": "0",
+      "dispenseWithNotice": "Yes",
+      "solsPaymentMethods": "fee account",
+      "solsSolicitorEmail": "vleholt@yahoo.co.uk",
+      "willAccessOriginal": "Yes",
+      "deceasedDateOfBirth": "1978-01-10",
+      "deceasedDateOfDeath": "2021-01-10",
+      "otherExecutorExists": "Yes",
+      "solsSOTNeedToUpdate": "No",
+      "solsSolicitorIsExec": "No",
+      "codicilAddedDateList": [{
+        "id": "78dce55b-7a58-4bc0-8b88-baa5cc9a2e87",
+        "value": {
+          "dateCodicilAdded": "1992-10-10"
+        }
+      }],
+      "executorsNotApplying": [{
+        "id": "4ef60e4c-b613-4033-a365-0625e95b0e26",
+        "value": {
+          "notApplyingExecutorName": "Jim Smith",
+          "notApplyingExecutorReason": "PowerReserved",
+          "notApplyingExecutorNotified": null,
+          "notApplyingExecutorNameOnWill": null,
+          "notApplyingExecutorDispenseWithNotice": "Yes",
+          "notApplyingExecutorNameDifferenceComment": null,
+          "notApplyingExecutorDispenseWithNoticeLeaveGiven": "Yes",
+          "notApplyingExecutorDispenseWithNoticeLeaveGivenDate": "1956-09-10"
+        }
+      },
+        {
+          "id": "5361a490-8537-4314-a9c3-36f09ce62610",
+          "value": {
+            "notApplyingExecutorName": "Keith Jones",
+            "notApplyingExecutorReason": "DiedBefore",
+            "notApplyingExecutorNotified": null,
+            "notApplyingExecutorNameOnWill": null,
+            "notApplyingExecutorDispenseWithNotice": null,
+            "notApplyingExecutorNameDifferenceComment": null,
+            "notApplyingExecutorDispenseWithNoticeLeaveGiven": null,
+            "notApplyingExecutorDispenseWithNoticeLeaveGivenDate": null
+          }
+        }
+      ],
+      "solsFeeAccountNumber": "001234",
+      "solsSolicitorAddress": {
+        "County": "Glos",
+        "Country": "United Kingdom",
+        "PostCode": "GL52 6UW",
+        "PostTown": "Cheltenham",
+        "AddressLine1": "1 Woodmeade Close",
+        "AddressLine2": "Charlton Kings",
+        "AddressLine3": null
+      },
+      "titleAndClearingType": "TCTPartPowerRes",
+      "deceasedAnyOtherNames": "No",
+      "nameOfFirmNamedInWill": "fdgfg",
+      "solsSolicitorFirmName": "GGG",
+      "ihtFormCompletedOnline": "No",
+      "originalWillSignedDate": "1981-10-10",
+      "primaryApplicantAddress": {
+        "County": "Glos",
+        "Country": "United Kingdom",
+        "PostCode": "GL52 6UW",
+        "PostTown": "Cheltenham",
+        "AddressLine1": "1 Woodmeade Close",
+        "AddressLine2": "Charlton Kings",
+        "AddressLine3": null
+      },
+      "primaryApplicantSurname": "Smith",
+      "solsSolicitorIsApplying": "Yes",
+      "addressOfFirmNamedInWill": {
+        "County": "Wilts",
+        "Country": "United Kingdom",
+        "PostCode": "Sn2 2JU",
+        "PostTown": "Swindon",
+        "AddressLine1": "1 Commercial Rd",
+        "AddressLine2": null,
+        "AddressLine3": null
+      },
+      "anyOtherApplyingPartners": "No",
+      "applicationSubmittedDate": "2021-05-04",
+      "primaryApplicantHasAlias": "No",
+      "solsSolicitorPhoneNumber": "07740189346",
+      "solsSolicitorWillSignSOT": "Yes",
+      "primaryApplicantForenames": "Fred",
+      "probateDocumentsGenerated": [],
+      "solsSolicitorAppReference": "HKHFHhg",
+      "whoSharesInCompanyProfits": [
+        "partner"
+      ],
+      "deceasedDomicileInEngWales": "Yes",
+      "primaryApplicantIsApplying": "Yes",
+      "solsAdditionalExecutorList": [],
+      "solsLegalStatementDocument": {
+        "document_url": "http://dm-store:8080/documents/b392e5b0-b0b5-48a1-b15d-6ffad8306122",
+        "document_filename": "legalStatementProbateTrustCorps.pdf",
+        "document_binary_url": "http://dm-store:8080/documents/b392e5b0-b0b5-48a1-b15d-6ffad8306122/binary"
+      },
+      "boCaveatStopSendToBulkPrint": "Yes",
+      "boRequestInfoSendToBulkPrint": "Yes",
+      "dispenseWithNoticeLeaveGiven": "Yes",
+      "probateSotDocumentsGenerated": [],
+      "solsAmendLegalStatmentSelect": {
+        "value": {
+          "code": "SolAppCreatedSolicitorDtls",
+          "label": "Probate practitioner details"
+        },
+        "list_items": [{
+          "code": "SolAppCreatedSolicitorDtls",
+          "label": "Probate practitioner details"
+        },
+          {
+            "code": "SolAppCreatedDeceasedDtls",
+            "label": "Deceased details"
+          },
+          {
+            "code": "WillLeft",
+            "label": "Probate details"
+          }
+        ]
+      },
+      "boCaveatStopEmailNotification": "No",
+      "boGrantReissueSendToBulkPrint": "Yes",
+      "probateNotificationsGenerated": [],
+      "boEmailGrantIssuedNotification": "Yes",
+      "boEmailRequestInfoNotification": "Yes",
+      "boAssembleLetterSendToBulkPrint": "Yes",
+      "boEmailDocsReceivedNotification": "Yes",
+      "boEmailGrantReissuedNotification": "Yes",
+      "dispenseWithNoticeLeaveGivenDate": "1956-09-10",
+      "dispenseWithNoticeOtherExecsList": [],
+      "morePartnersHoldingPowerReserved": "Yes",
+      "grantAwaitingDocumentationNotificationDate": "2021-06-08"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/probate/model/Constants.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/Constants.java
@@ -65,6 +65,8 @@ public final class Constants {
             TITLE_AND_CLEARING_TRUST_CORP_SDJ,
             TITLE_AND_CLEARING_TRUST_CORP));
 
+    public static final String SOLICITOR_ID = "solicitor";
+
     private Constants() {
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
@@ -19,21 +19,16 @@ import static uk.gov.hmcts.probate.model.Constants.EXECUTOR_NOT_APPLYING_REASON;
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.TRUST_CORP_TITLE_CLEARING_TYPES;
 import static uk.gov.hmcts.probate.model.Constants.YES;
+import static uk.gov.hmcts.probate.model.Constants.SOLICITOR_ID;
 
 @Slf4j
 @Service
 public class ExecutorListMapperService {
 
-    private static final String SOLICITOR_ID = "solicitor";
-
     public List<CollectionMember<AdditionalExecutorApplying>> addSolicitorToApplyingList(
             CaseData caseData, List<CollectionMember<AdditionalExecutorApplying>> execs) {
 
-        List<CollectionMember<AdditionalExecutorApplying>> updatedExecs = new ArrayList<>();
-
-        if (execs.stream().anyMatch(exec -> !SOLICITOR_ID.equals(exec.getId()))) {
-            updatedExecs = removeSolicitorFromApplyingList(execs);
-        }
+        var updatedExecs = removeSolicitorFromApplyingList(execs);
         updatedExecs.add(0, mapFromSolicitorToApplyingExecutor(caseData));
 
         return updatedExecs;
@@ -42,12 +37,8 @@ public class ExecutorListMapperService {
     public List<CollectionMember<AdditionalExecutorNotApplying>> addSolicitorToNotApplyingList(
             CaseData caseData, List<CollectionMember<AdditionalExecutorNotApplying>> execs) {
 
-        List<CollectionMember<AdditionalExecutorNotApplying>> updatedExecs = new ArrayList<>();
-
-        if (execs.stream().anyMatch(exec -> !SOLICITOR_ID.equals(exec.getId()))) {
-            updatedExecs = removeSolicitorFromNotApplyingList(execs);
-        }
-        updatedExecs.add(mapFromSolicitorToNotApplyingExecutor(caseData));
+        var updatedExecs = removeSolicitorFromNotApplyingList(execs);
+        updatedExecs.add(0, mapFromSolicitorToNotApplyingExecutor(caseData));
 
         return updatedExecs;
     }

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.probate.service.solicitorexecutor.FormattingService;
 import java.util.ArrayList;
 import java.util.List;
 
+import static uk.gov.hmcts.probate.model.Constants.SOLICITOR_ID;
+
 @Component
 @Slf4j
 public class LegalStatementExecutorTransformer extends ExecutorsTransformer {
@@ -50,10 +52,15 @@ public class LegalStatementExecutorTransformer extends ExecutorsTransformer {
                                              CaseData caseData) {
         // Add primary applicant to list
         if (caseData.isPrimaryApplicantApplying()) {
-            execsApplying.add(0, executorListMapperService.mapFromPrimaryApplicantToApplyingExecutor(caseData));
+            if (!execsApplying.stream().anyMatch(exec -> SOLICITOR_ID.equals(exec.getId()))) {
+                execsApplying.add(0,
+                        executorListMapperService.mapFromPrimaryApplicantToApplyingExecutor(caseData));
+            }
         } else if (caseData.isPrimaryApplicantNotApplying()) {
-            execsNotApplying.add(0, executorListMapperService
-                    .mapFromPrimaryApplicantToNotApplyingExecutor(caseData));
+            if (!execsNotApplying.stream().anyMatch(exec -> SOLICITOR_ID.equals(exec.getId()))) {
+                execsNotApplying.add(0, executorListMapperService
+                        .mapFromPrimaryApplicantToNotApplyingExecutor(caseData));
+            }
         }
 
         /* old code - remove once new code tested more thoroughly

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
@@ -52,27 +52,28 @@ public class LegalStatementExecutorTransformer extends ExecutorsTransformer {
                                              CaseData caseData) {
         // Add primary applicant to list
         if (caseData.isPrimaryApplicantApplying()) {
-            if (!execsApplying.stream().anyMatch(exec -> SOLICITOR_ID.equals(exec.getId()))) {
-                execsApplying.add(0,
-                        executorListMapperService.mapFromPrimaryApplicantToApplyingExecutor(caseData));
+            // solicitor will always be at position 0
+            if (execsApplying.size() > 0 && SOLICITOR_ID.equals(execsApplying.get(0).getId())) {
+                execsApplying.remove(0);
             }
+            // retain primary applicant fields mapping, rather than using solicitor details
+            // (which have been mapped to primary applicant fields)
+            // in order that legal statement matches issue grant template which uses primary applicant fields
+            // (to cater for cw amend of one but not the other)
+            execsApplying.add(0, executorListMapperService
+                    .mapFromPrimaryApplicantToApplyingExecutor(caseData));
         } else if (caseData.isPrimaryApplicantNotApplying()) {
-            if (!execsNotApplying.stream().anyMatch(exec -> SOLICITOR_ID.equals(exec.getId()))) {
-                execsNotApplying.add(0, executorListMapperService
-                        .mapFromPrimaryApplicantToNotApplyingExecutor(caseData));
+            // solicitor will always be at position 0
+            if (execsNotApplying.size() > 0 && SOLICITOR_ID.equals(execsNotApplying.get(0).getId())) {
+                execsNotApplying.remove(0);
             }
+            // retain primary applicant fields mapping, rather than using solicitor details
+            // (which have been mapped to primary applicant fields)
+            // in order that legal statement matches issue grant template which uses primary applicant fields
+            // (to cater for cw amend of one but not the other)
+            execsNotApplying.add(0, executorListMapperService
+                    .mapFromPrimaryApplicantToNotApplyingExecutor(caseData));
         }
-
-        /* old code - remove once new code tested more thoroughly
-            // Add primary applicant to list
-            if (isSolicitorExecutor(caseData) && isSolicitorApplying(caseData)) {
-                execsApplying.add(executorListMapperService.mapFromSolicitorToApplyingExecutor(caseData));
-            } else if (caseData.isPrimaryApplicantApplying()) {
-                execsApplying.add(executorListMapperService.mapFromPrimaryApplicantToApplyingExecutor(caseData));
-            } else if (caseData.isPrimaryApplicantNotApplying()) {
-                execsNotApplying.add(executorListMapperService.mapFromPrimaryApplicantToNotApplyingExecutor(caseData));
-            }
-         */
 
         caseData.setExecutorsApplyingLegalStatement(execsApplying);
         caseData.setExecutorsNotApplyingLegalStatement(execsNotApplying);

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformer.java
@@ -53,7 +53,7 @@ public class LegalStatementExecutorTransformer extends ExecutorsTransformer {
         // Add primary applicant to list
         if (caseData.isPrimaryApplicantApplying()) {
             // solicitor will always be at position 0
-            if (execsApplying.size() > 0 && SOLICITOR_ID.equals(execsApplying.get(0).getId())) {
+            if (!execsApplying.isEmpty() && SOLICITOR_ID.equals(execsApplying.get(0).getId())) {
                 execsApplying.remove(0);
             }
             // retain primary applicant fields mapping, rather than using solicitor details
@@ -64,7 +64,7 @@ public class LegalStatementExecutorTransformer extends ExecutorsTransformer {
                     .mapFromPrimaryApplicantToApplyingExecutor(caseData));
         } else if (caseData.isPrimaryApplicantNotApplying()) {
             // solicitor will always be at position 0
-            if (execsNotApplying.size() > 0 && SOLICITOR_ID.equals(execsNotApplying.get(0).getId())) {
+            if (!execsNotApplying.isEmpty() && SOLICITOR_ID.equals(execsNotApplying.get(0).getId())) {
                 execsNotApplying.remove(0);
             }
             // retain primary applicant fields mapping, rather than using solicitor details

--- a/src/main/resources/templates/pdf/legalStatementProbateTrustCorps.html
+++ b/src/main/resources/templates/pdf/legalStatementProbateTrustCorps.html
@@ -158,7 +158,7 @@
 
             {% if executor.value.applyingExecutorType == "Named" %}
             <p>
-                {{ executor.value.applyingExecutorName }}, {% if multipleExecutors %}an{% else %}the{% endif %} executor named in the will{% if numberOfCodicils == 1 %} or codicil {% elseif numberOfCodicils > 1 %} or codicils{% endif %}{% if executor.value.applyingExecutorOtherNames != null %} as {{ executor.value.applyingExecutorOtherNames }}{% endif %},
+                {{ executor.value.applyingExecutorName }}, {% if multipleExecutors %}an{% else %}the{% endif %} executor named in the will{% if numberOfCodicils == 1 %} or codicil{% elseif numberOfCodicils > 1 %} or codicils{% endif %}{% if executor.value.applyingExecutorOtherNames != null %} as {{ executor.value.applyingExecutorOtherNames }}{% endif %},
                 is applying for probate.
             </p>
             {% endif %}

--- a/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
@@ -349,5 +349,71 @@ public class ExecutorListMapperServiceTest {
         assertEquals(result.getValue(), expected.getValue());
     }
 
+    public void shouldMapFromSolicitorToApplyingExecutorTrustCorps() {
+        CaseData.CaseDataBuilder<?, ?> caseDataBuilder = CaseData.builder()
+                .solsSOTForenames(SOLICITOR_SOT_FORENAME)
+                .solsSOTSurname(SOLICITOR_SOT_SURNAME)
+                .solsSolicitorAddress(SOLICITOR_ADDRESS)
+                .solsSolicitorNotApplyingReason(SOLICITOR_NOT_APPLYING_REASON)
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .primaryApplicantSurname(EXEC_SURNAME)
+                .primaryApplicantAddress(EXEC_ADDRESS)
+                .solsExecutorAliasNames(EXEC_OTHER_NAMES)
+                .primaryApplicantAliasReason(EXEC_OTHER_NAMES_REASON)
+                .probatePractitionersPositionInTrust(DIRECTOR)
+                .titleAndClearingType(TITLE_AND_CLEARING_TRUST_CORP_SDJ)
+                .solsSolicitorIsExec(NO)
+                .solsSolicitorIsApplying(YES);
 
+        CollectionMember<AdditionalExecutorApplying> result =
+                underTest.mapFromSolicitorToApplyingExecutor(caseDataBuilder.build());
+
+        CollectionMember<AdditionalExecutorApplying> expected = new CollectionMember(
+                SOLICITOR_ID, AdditionalExecutorApplying.builder()
+                .applyingExecutorFirstName(SOLICITOR_SOT_FORENAME)
+                .applyingExecutorLastName(SOLICITOR_SOT_SURNAME)
+                .applyingExecutorName(SOLICITOR_SOT_FULLNAME)
+                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorAddress(SOLICITOR_ADDRESS)
+                .applyingExecutorTrustCorpPosition(DIRECTOR)
+                .build());
+
+        assertEquals(expected.getValue(), result.getValue());
+    }
+
+    @Test
+    public void shouldMapFromPrimaryApplicantToApplyingExecutorTrustCorps() {
+
+        CaseData.CaseDataBuilder<?, ?> caseDataBuilder = CaseData.builder()
+                .solsSOTForenames(SOLICITOR_SOT_FORENAME)
+                .solsSOTSurname(SOLICITOR_SOT_SURNAME)
+                .solsSolicitorAddress(SOLICITOR_ADDRESS)
+                .solsSolicitorNotApplyingReason(SOLICITOR_NOT_APPLYING_REASON)
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .primaryApplicantSurname(EXEC_SURNAME)
+                .primaryApplicantAddress(EXEC_ADDRESS)
+                .solsExecutorAliasNames(EXEC_OTHER_NAMES)
+                .primaryApplicantAliasReason(EXEC_OTHER_NAMES_REASON)
+                .probatePractitionersPositionInTrust(DIRECTOR)
+                .titleAndClearingType(TITLE_AND_CLEARING_TRUST_CORP_SDJ)
+                .solsSolicitorIsExec(NO)
+                .solsSolicitorIsApplying(YES);
+
+        CollectionMember<AdditionalExecutorApplying> result =
+                underTest.mapFromPrimaryApplicantToApplyingExecutor(caseDataBuilder.build());
+
+        CollectionMember<AdditionalExecutorApplying> expected = new CollectionMember(
+                null, AdditionalExecutorApplying.builder()
+                .applyingExecutorFirstName(EXEC_FIRST_NAME)
+                .applyingExecutorLastName(EXEC_SURNAME)
+                .applyingExecutorName(EXEC_NAME)
+                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorAddress(EXEC_ADDRESS)
+                .applyingExecutorOtherNames(EXEC_OTHER_NAMES)
+                .applyingExecutorOtherNamesReason(EXEC_OTHER_NAMES_REASON)
+                .applyingExecutorTrustCorpPosition(DIRECTOR)
+                .build());
+
+        assertEquals(result.getValue(), expected.getValue());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
@@ -107,8 +107,8 @@ public class ExecutorListMapperServiceTest {
                         additionalExecutorsNotApplyingMock);
 
         assertEquals(2, newExecsNotApplying.size());
-        assertEquals(SOLICITOR_SOT_FULLNAME, newExecsNotApplying.get(1).getValue().getNotApplyingExecutorName());
-        assertEquals(SOLICITOR_ID, newExecsNotApplying.get(1).getId());
+        assertEquals(SOLICITOR_SOT_FULLNAME, newExecsNotApplying.get(0).getValue().getNotApplyingExecutorName());
+        assertEquals(SOLICITOR_ID, newExecsNotApplying.get(0).getId());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ExecutorListMapperServiceTest {
                         additionalExecutorsNotApplyingMock);
 
         assertEquals(2, newExecsNotApplying.size());
-        assertEquals(SOLICITOR_ID, newExecsNotApplying.get(1).getId());
+        assertEquals(SOLICITOR_ID, newExecsNotApplying.get(0).getId());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -330,11 +330,6 @@ public class LegalStatementExecutorTransformerTest {
 
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
 
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
-                caseDetailsMock.getData())).thenReturn(
-                new CollectionMember<>("solicitor", EXECUTOR_NOT_APPLYING));
-
-
         List<CollectionMember<AdditionalExecutorApplying>> execsApplying = new ArrayList<>();
 
         List<CollectionMember<AdditionalExecutorNotApplying>> execsNotApplying =

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -326,9 +326,12 @@ public class LegalStatementExecutorTransformerTest {
                 .primaryApplicantSurname(EXEC_SURNAME)
                 .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
                 .primaryApplicantAddress(EXEC_ADDRESS)
-                .primaryApplicantIsApplying(YES);
+                .primaryApplicantIsApplying(NO);
 
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
+                caseDetailsMock.getData())).thenReturn(
+                new CollectionMember<>("12345", EXECUTOR_NOT_APPLYING));
 
         List<CollectionMember<AdditionalExecutorApplying>> execsApplying = new ArrayList<>();
 
@@ -342,7 +345,7 @@ public class LegalStatementExecutorTransformerTest {
 
         CaseData caseData = caseDetailsMock.getData();
         assertEquals(1, execsNotApplying.size());
-        assertEquals("solicitor", execsNotApplying.get(0).getId());
+        assertEquals("12345", execsNotApplying.get(0).getId());
         assertEquals(1, caseData.getExecutorsNotApplyingLegalStatement().size());
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -316,4 +316,36 @@ public class LegalStatementExecutorTransformerTest {
         assertEquals("12345", execsApplying.get(0).getId());
         assertEquals(new ArrayList<>(), caseData.getExecutorsNotApplyingLegalStatement());
     }
+
+    @Test
+    public void shouldNotSetNotApplyingSolicitorAsExecutorTwice() {
+        caseDataBuilder
+                .solsSolicitorIsApplying(NO)
+                .solsSolicitorIsExec(YES)
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .primaryApplicantSurname(EXEC_SURNAME)
+                .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
+                .primaryApplicantAddress(EXEC_ADDRESS)
+                .primaryApplicantIsApplying(YES);
+
+        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
+                caseDetailsMock.getData())).thenReturn(
+                new CollectionMember<>("12345", EXECUTOR_APPLYING));
+
+        List<CollectionMember<AdditionalExecutorApplying>> execsApplying = new ArrayList<>();
+
+        List<CollectionMember<AdditionalExecutorNotApplying>> execsNotApplying =
+                new ArrayList<>();
+        execsNotApplying.add(new CollectionMember<>(SOLICITOR_ID, EXECUTOR_NOT_APPLYING));
+
+        legalStatementExecutorTransformerMock.createLegalStatementExecutorLists(execsApplying,
+                execsNotApplying,
+                caseDetailsMock.getData());
+
+        CaseData caseData = caseDetailsMock.getData();
+        assertEquals(1, execsNotApplying.size());
+        assertEquals("12345", execsNotApplying.get(0).getId());
+        assertEquals(new ArrayList<>(), caseData.getExecutorsApplyingLegalStatement());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -312,8 +312,8 @@ public class LegalStatementExecutorTransformerTest {
                 caseDetailsMock.getData());
 
         CaseData caseData = caseDetailsMock.getData();
-        assertEquals(execsApplying.size(), 1);
-        assertEquals(execsApplying.get(0).getId(), "12345");
+        assertEquals(1, execsApplying.size());
+        assertEquals("12345", execsApplying.get(0).getId());
         assertEquals(new ArrayList<>(), caseData.getExecutorsNotApplyingLegalStatement());
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -20,9 +20,9 @@ import uk.gov.hmcts.probate.service.DateFormatterService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.Constants.SOLICITOR_ID;
@@ -235,7 +235,7 @@ public class LegalStatementExecutorTransformerTest {
 
     @Test
     public void shouldOutputCorrectSingularWhoSharesInProfitText() {
-        final List<String> companyProfits = new ArrayList<>(Arrays.asList("Partners", "Shareholders"));
+        final List<String> companyProfits = new ArrayList<>(asList("Partners", "Shareholders"));
 
         final CaseData caseData = CaseData.builder()
                 .whoSharesInCompanyProfits(companyProfits)
@@ -248,7 +248,7 @@ public class LegalStatementExecutorTransformerTest {
 
     @Test
     public void shouldOutputCorrectPluralWhoSharesInProfitText() {
-        final List<String> companyProfits = new ArrayList<>(Arrays.asList("Partners", "Shareholders"));
+        final List<String> companyProfits = new ArrayList<>(asList("Partners", "Shareholders"));
 
         final CaseData caseData = CaseData.builder()
                 .whoSharesInCompanyProfits(companyProfits)
@@ -261,7 +261,7 @@ public class LegalStatementExecutorTransformerTest {
 
     @Test
     public void shouldOutputCorrectSingularWhoSharesInProfitText_SingularValue() {
-        final List<String> companyProfits = new ArrayList<>(Arrays.asList("Partner", "Shareholder"));
+        final List<String> companyProfits = new ArrayList<>(asList("Partner", "Shareholder"));
 
         final CaseData caseData = CaseData.builder()
                 .whoSharesInCompanyProfits(companyProfits)
@@ -274,7 +274,7 @@ public class LegalStatementExecutorTransformerTest {
 
     @Test
     public void shouldOutputCorrectPluralWhoSharesInProfitText_SingularValue() {
-        final List<String> companyProfits = new ArrayList<>(Arrays.asList("Partner", "Shareholder"));
+        final List<String> companyProfits = new ArrayList<>(asList("Partner", "Shareholder"));
 
         final CaseData caseData = CaseData.builder()
                 .whoSharesInCompanyProfits(companyProfits)
@@ -296,18 +296,16 @@ public class LegalStatementExecutorTransformerTest {
                 .primaryApplicantAddress(EXEC_ADDRESS)
                 .primaryApplicantIsApplying(YES);
 
-        List<CollectionMember<AdditionalExecutorApplying>> execsApplying =
-                new ArrayList<>();
-
-        List<CollectionMember<AdditionalExecutorNotApplying>> execsNotApplying =
-                new ArrayList<>();
-
-        execsApplying.add(new CollectionMember<>(SOLICITOR_ID, EXECUTOR_APPLYING));
-
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
         when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
                 caseDetailsMock.getData())).thenReturn(
-                        new CollectionMember<>("12345", EXECUTOR_APPLYING));
+                new CollectionMember<>("12345", EXECUTOR_APPLYING));
+
+        List<CollectionMember<AdditionalExecutorApplying>> execsApplying = new ArrayList<>();
+        execsApplying.add(new CollectionMember<>(SOLICITOR_ID, EXECUTOR_APPLYING));
+
+        List<CollectionMember<AdditionalExecutorNotApplying>> execsNotApplying =
+                new ArrayList<>();
 
         legalStatementExecutorTransformerMock.createLegalStatementExecutorLists(execsApplying, 
                 execsNotApplying,

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/LegalStatementExecutorTransformerTest.java
@@ -329,9 +329,11 @@ public class LegalStatementExecutorTransformerTest {
                 .primaryApplicantIsApplying(YES);
 
         when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
+
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
                 caseDetailsMock.getData())).thenReturn(
-                new CollectionMember<>("12345", EXECUTOR_APPLYING));
+                new CollectionMember<>("solicitor", EXECUTOR_NOT_APPLYING));
+
 
         List<CollectionMember<AdditionalExecutorApplying>> execsApplying = new ArrayList<>();
 
@@ -345,7 +347,7 @@ public class LegalStatementExecutorTransformerTest {
 
         CaseData caseData = caseDetailsMock.getData();
         assertEquals(1, execsNotApplying.size());
-        assertEquals("12345", execsNotApplying.get(0).getId());
-        assertEquals(new ArrayList<>(), caseData.getExecutorsApplyingLegalStatement());
+        assertEquals("solicitor", execsNotApplying.get(0).getId());
+        assertEquals(1, caseData.getExecutorsNotApplyingLegalStatement().size());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPB-1930


### Change description ###
Fix bug with solicitor appearing twice in executor list
Also a minor issue with a space after a comma in sot template

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
