### PR TITLE
Dtspb 1955 fix solicitor always named bug

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/documents/SolBaCcdServiceDocumentsTests.java
@@ -1450,7 +1450,7 @@ public class SolBaCcdServiceDocumentsTests extends IntegrationTestBase {
         String response = generatePdfDocument(NO_DUPE_SOL_EXECUTORS, GENERATE_LEGAL_STATEMENT);
         assertTrue(response
                 .contains("The executor believes that all the information stated in the legal statement is true."));
-        assertTrue(response.contains("Fred Smith, the executor named in the will or codicil, is applying for probate"));
+        assertTrue(response.contains("Fred Smith, is a profit-sharing partner in the firm , at the date of death"));
         assertTrue(response.split("Fred Smith").length == 5);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
@@ -226,11 +226,11 @@ public class ExecutorListMapperService {
                 .build());
     }
 
-    private String getSolExecType(CaseData caseData){
+    private String getSolExecType(CaseData caseData) {
         String executorType = "";
 
         if (NO.equals(caseData.getSolsSolicitorIsExec()) && YES.equals(caseData.getSolsSolicitorIsApplying())
-        && getNonTrustPtnrTitleClearingTypes().contains(caseData.getTitleAndClearingType())) {
+            && getNonTrustPtnrTitleClearingTypes().contains(caseData.getTitleAndClearingType())) {
             executorType = EXECUTOR_TYPE_PROFESSIONAL;
         } else if (NO.equals(caseData.getSolsSolicitorIsExec()) && YES.equals(caseData.getSolsSolicitorIsApplying())
             && getTrustCorpTitleClearingTypes().contains(caseData.getTitleAndClearingType())) {

--- a/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperService.java
@@ -19,6 +19,7 @@ import static uk.gov.hmcts.probate.model.Constants.EXECUTOR_TYPE_TRUST_CORP;
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.YES;
 import static uk.gov.hmcts.probate.model.Constants.getTrustCorpTitleClearingTypes;
+import static uk.gov.hmcts.probate.model.Constants.getNonTrustPtnrTitleClearingTypes;
 import static uk.gov.hmcts.probate.model.Constants.SOLICITOR_ID;
 
 @Slf4j
@@ -156,7 +157,7 @@ public class ExecutorListMapperService {
                         .applyingExecutorName(FormattingService.capitaliseEachWord(
                                 exec.getValue().getAdditionalExecForenames()
                                 + " " + exec.getValue().getAdditionalExecLastname()))
-                        .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                        .applyingExecutorType(getSolExecType(caseData))
                         .applyingExecutorOtherNames(exec.getValue().getAdditionalExecAliasNameOnWill())
                         .build()))
                 .collect(Collectors.toList());
@@ -185,7 +186,7 @@ public class ExecutorListMapperService {
                 .applyingExecutorLastName(FormattingService.capitaliseEachWord(caseData.getSolsSOTSurname()))
                 .applyingExecutorName(FormattingService.capitaliseEachWord(caseData.getSolsSOTForenames()
                         + " " + caseData.getSolsSOTSurname()))
-                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorType(getSolExecType(caseData))
                 .applyingExecutorAddress(caseData.getSolsSolicitorAddress())
                 .applyingExecutorTrustCorpPosition(
                         getTrustCorpTitleClearingTypes().contains(caseData.getTitleAndClearingType())
@@ -203,7 +204,7 @@ public class ExecutorListMapperService {
                         caseData.getPrimaryApplicantForenames()))
                 .applyingExecutorLastName(FormattingService.capitaliseEachWord(caseData.getPrimaryApplicantSurname()))
                 .applyingExecutorName(FormattingService.capitaliseEachWord(caseData.getPrimaryApplicantFullName()))
-                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorType(getSolExecType(caseData))
                 .applyingExecutorAddress(caseData.getPrimaryApplicantAddress())
                 .applyingExecutorOtherNames(caseData.getSolsExecutorAliasNames())
                 .applyingExecutorOtherNamesReason(caseData.getPrimaryApplicantAliasReason())
@@ -223,6 +224,22 @@ public class ExecutorListMapperService {
                 .notApplyingExecutorReason(caseData.getSolsPrimaryExecutorNotApplyingReason())
                 .notApplyingExecutorNameOnWill(caseData.getSolsExecutorAliasNames())
                 .build());
+    }
+
+    private String getSolExecType(CaseData caseData){
+        String executorType = "";
+
+        if (NO.equals(caseData.getSolsSolicitorIsExec()) && YES.equals(caseData.getSolsSolicitorIsApplying())
+        && getNonTrustPtnrTitleClearingTypes().contains(caseData.getTitleAndClearingType())) {
+            executorType = EXECUTOR_TYPE_PROFESSIONAL;
+        } else if (NO.equals(caseData.getSolsSolicitorIsExec()) && YES.equals(caseData.getSolsSolicitorIsApplying())
+            && getTrustCorpTitleClearingTypes().contains(caseData.getTitleAndClearingType())) {
+            executorType = EXECUTOR_TYPE_TRUST_CORP;
+        } else {
+            executorType = EXECUTOR_TYPE_NAMED;
+        }
+
+        return executorType;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/solicitorexecutor/ExecutorListMapperServiceTest.java
@@ -326,13 +326,12 @@ public class ExecutorListMapperServiceTest {
                 .applyingExecutorFirstName(EXEC_FIRST_NAME)
                 .applyingExecutorLastName(EXEC_SURNAME)
                 .applyingExecutorName(EXEC_NAME)
-                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorType(EXECUTOR_TYPE_TRUST_CORP)
                 .applyingExecutorAddress(EXEC_ADDRESS)
                 .applyingExecutorOtherNames(EXEC_OTHER_NAMES)
                 .applyingExecutorOtherNamesReason(EXEC_OTHER_NAMES_REASON)
                 .applyingExecutorTrustCorpPosition(DIRECTOR)
                 .build());
-
         assertEquals(result.getValue(), expected.getValue());
     }
 
@@ -407,7 +406,7 @@ public class ExecutorListMapperServiceTest {
                 .applyingExecutorFirstName(EXEC_FIRST_NAME)
                 .applyingExecutorLastName(EXEC_SURNAME)
                 .applyingExecutorName(EXEC_NAME)
-                .applyingExecutorType(EXECUTOR_TYPE_NAMED)
+                .applyingExecutorType(EXECUTOR_TYPE_TRUST_CORP)
                 .applyingExecutorAddress(EXEC_ADDRESS)
                 .applyingExecutorOtherNames(EXEC_OTHER_NAMES)
                 .applyingExecutorOtherNamesReason(EXEC_OTHER_NAMES_REASON)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPB-1955


### Change description ###
Executor type for solicitor was always Named, now fixed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
