### PR TITLE
DTSPB-3648 upgrade netty for fix CVE-2022-24823

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencyManagement {
   }
   dependencies {
     // CVE-2022-24823
-    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.94.Final') {
       entry 'netty-buffer'
       entry 'netty-codec'
       entry 'netty-codec-dns'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPB-3648


### Change description ###
upgrade netty for fix CVE-2022-24823


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
