### PR TITLE
Bump ccd chart version to latest

### DIFF
--- a/charts/probate-back-office/Chart.yaml
+++ b/charts/probate-back-office/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for the HMCTS probate back office service
 name: probate-back-office
 home: https://github.com/hmcts/probate-back-office
-version: 1.0.45
+version: 1.0.46
 maintainers:
   - name: HMCTS Probate Team
     email: probate-action-group@HMCTS.NET

--- a/charts/probate-back-office/Chart.yaml
+++ b/charts/probate-back-office/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version:  5.2.1
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
-    version: 9.0.22
+    version: 9.2.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     tags:
       - probate-ccd-stack


### PR DESCRIPTION
Bumps chart-ccd to latest so that all mention of aadpodidentity is removed -- checked all pods in this PR deployment and none have the label anymore

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
