### PR TITLE
DTSPB-4380 Update markdown filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 
   implementation group: 'org.pitest', name: 'pitest', version: '1.17.0'
-  implementation group: 'com.atlassian.commonmark', name: 'commonmark', version: '0.17.0'
+  implementation group: 'org.commonmark', name: 'commonmark', version: '0.23.0'
   implementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.15.0'
   implementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
 

--- a/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
@@ -21,6 +21,7 @@ import org.commonmark.node.IndentedCodeBlock;
 import org.commonmark.node.Link;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.node.ListItem;
+import org.commonmark.node.Node;
 import org.commonmark.node.OrderedList;
 import org.commonmark.node.Paragraph;
 import org.commonmark.node.SoftLineBreak;
@@ -45,6 +46,24 @@ public class MarkdownValidatorService {
         private boolean invalid = false;
 
         private final String key;
+
+        @Override
+        public void visitChildren(Node parent) {
+            Node node = parent.getFirstChild();
+            while (node != null) {
+                // If we have seen any failure we do not need to continue searching the Node tree, so short circuit
+                if (invalid) {
+                    log.trace("{}: has been rejected, short circuit", key);
+                    return;
+                }
+
+                // A subclass of this visitor might modify the node, resulting in getNext returning a different node or
+                // no node after visiting it. So get the next node before visiting.
+                final Node next = node.getNext();
+                node.accept(this);
+                node = next;
+            }
+        }
 
         @Override
         public void visit(BlockQuote blockQuote) {

--- a/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
@@ -1,0 +1,186 @@
+package uk.gov.hmcts.probate.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.BulletList;
+import org.commonmark.node.Code;
+import org.commonmark.node.CustomBlock;
+import org.commonmark.node.CustomNode;
+import org.commonmark.node.Document;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.OrderedList;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.StrongEmphasis;
+import org.commonmark.node.Text;
+import org.commonmark.node.ThematicBreak;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class MarkdownValidatorService {
+
+    public NontextVisitor getNontextVisitor(final String key) {
+        return new NontextVisitor(key);
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor
+    public static class NontextVisitor extends AbstractVisitor {
+        @Getter
+        private boolean invalid = false;
+
+        private final String key;
+
+        @Override
+        public void visit(BlockQuote blockQuote) {
+            log.debug("{}: visit BlockQuote", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(BulletList bulletList) {
+            log.debug("{}: visit BulletList", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Code code) {
+            log.debug("{}: visit Code", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Document document) {
+            log.debug("{}: visit Document", key);
+            visitChildren(document);
+        }
+
+        @Override
+        public void visit(Emphasis emphasis) {
+            log.debug("{}: visit Emphasis", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(FencedCodeBlock fencedCodeBlock) {
+            log.debug("{}: visit FencedCodeBlock", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(HardLineBreak hardLineBreak) {
+            log.debug("{}: visit HardLineBreak", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Heading heading) {
+            log.debug("{}: visit Heading", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(ThematicBreak thematicBreak) {
+            log.debug("{}: visit ThematicBreak", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(HtmlInline htmlInline) {
+            log.debug("{}: visit HtmlInline", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(HtmlBlock htmlBlock) {
+            log.debug("{}: visit HtmlBlock", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Image image) {
+            log.debug("{}: visit Image", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(IndentedCodeBlock indentedCodeBlock) {
+            log.debug("{}: visit IndentedCodeBlock", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Link link) {
+            log.debug("{}: visit Link", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(ListItem listItem) {
+            log.debug("{}: visit ListItem", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(OrderedList orderedList) {
+            log.debug("{}: visit OrderedList", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Paragraph paragraph) {
+            log.debug("{}: visit Paragraph", key);
+            visitChildren(paragraph);
+        }
+
+        @Override
+        public void visit(SoftLineBreak softLineBreak) {
+            log.debug("{}: visit SoftLineBreak", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(StrongEmphasis strongEmphasis) {
+            log.debug("{}: visit StrongEmphasis", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(Text text) {
+            log.debug("{}: visit Text", key);
+            visitChildren(text);
+        }
+
+        @Override
+        public void visit(LinkReferenceDefinition linkReferenceDefinition) {
+            log.debug("{}: visit LinkReferenceDefinition", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(CustomBlock customBlock) {
+            log.debug("{}: visit CustomBlock", key);
+            invalid = true;
+        }
+
+        @Override
+        public void visit(CustomNode customNode) {
+            log.debug("{}: visit CustomNode", key);
+            invalid = true;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class MarkdownValidatorService {
 
     public NontextVisitor getNontextVisitor(final String key) {
@@ -47,139 +48,139 @@ public class MarkdownValidatorService {
 
         @Override
         public void visit(BlockQuote blockQuote) {
-            log.debug("{}: visit BlockQuote", key);
+            log.trace("{}: reject BlockQuote", key);
             invalid = true;
         }
 
         @Override
         public void visit(BulletList bulletList) {
-            log.debug("{}: visit BulletList", key);
-            invalid = true;
+            log.trace("{}: visit BulletList", key);
+            visitChildren(bulletList);
         }
 
         @Override
         public void visit(Code code) {
-            log.debug("{}: visit Code", key);
+            log.trace("{}: reject Code", key);
             invalid = true;
         }
 
         @Override
         public void visit(Document document) {
-            log.debug("{}: visit Document", key);
+            log.trace("{}: visit Document", key);
             visitChildren(document);
         }
 
         @Override
         public void visit(Emphasis emphasis) {
-            log.debug("{}: visit Emphasis", key);
+            log.trace("{}: reject Emphasis", key);
             invalid = true;
         }
 
         @Override
         public void visit(FencedCodeBlock fencedCodeBlock) {
-            log.debug("{}: visit FencedCodeBlock", key);
+            log.trace("{}: reject FencedCodeBlock", key);
             invalid = true;
         }
 
         @Override
         public void visit(HardLineBreak hardLineBreak) {
-            log.debug("{}: visit HardLineBreak", key);
-            invalid = true;
+            log.trace("{}: visit HardLineBreak", key);
+            visitChildren(hardLineBreak);
         }
 
         @Override
         public void visit(Heading heading) {
-            log.debug("{}: visit Heading", key);
-            invalid = true;
+            log.trace("{}: visit Heading", key);
+            visitChildren(heading);
         }
 
         @Override
         public void visit(ThematicBreak thematicBreak) {
-            log.debug("{}: visit ThematicBreak", key);
-            invalid = true;
+            log.trace("{}: visit ThematicBreak", key);
+            visitChildren(thematicBreak);
         }
 
         @Override
         public void visit(HtmlInline htmlInline) {
-            log.debug("{}: visit HtmlInline", key);
+            log.trace("{}: reject HtmlInline", key);
             invalid = true;
         }
 
         @Override
         public void visit(HtmlBlock htmlBlock) {
-            log.debug("{}: visit HtmlBlock", key);
+            log.trace("{}: reject HtmlBlock", key);
             invalid = true;
         }
 
         @Override
         public void visit(Image image) {
-            log.debug("{}: visit Image", key);
+            log.trace("{}: reject Image", key);
             invalid = true;
         }
 
         @Override
         public void visit(IndentedCodeBlock indentedCodeBlock) {
-            log.debug("{}: visit IndentedCodeBlock", key);
+            log.trace("{}: reject IndentedCodeBlock", key);
             invalid = true;
         }
 
         @Override
         public void visit(Link link) {
-            log.debug("{}: visit Link", key);
+            log.trace("{}: reject Link", key);
             invalid = true;
         }
 
         @Override
         public void visit(ListItem listItem) {
-            log.debug("{}: visit ListItem", key);
-            invalid = true;
+            log.trace("{}: visit ListItem", key);
+            visitChildren(listItem);
         }
 
         @Override
         public void visit(OrderedList orderedList) {
-            log.debug("{}: visit OrderedList", key);
-            invalid = true;
+            log.trace("{}: visit OrderedList", key);
+            visitChildren(orderedList);
         }
 
         @Override
         public void visit(Paragraph paragraph) {
-            log.debug("{}: visit Paragraph", key);
+            log.trace("{}: visit Paragraph", key);
             visitChildren(paragraph);
         }
 
         @Override
         public void visit(SoftLineBreak softLineBreak) {
-            log.debug("{}: visit SoftLineBreak", key);
-            invalid = true;
+            log.trace("{}: visit SoftLineBreak", key);
+            visitChildren(softLineBreak);
         }
 
         @Override
         public void visit(StrongEmphasis strongEmphasis) {
-            log.debug("{}: visit StrongEmphasis", key);
+            log.trace("{}: reject StrongEmphasis", key);
             invalid = true;
         }
 
         @Override
         public void visit(Text text) {
-            log.debug("{}: visit Text", key);
+            log.trace("{}: visit Text", key);
             visitChildren(text);
         }
 
         @Override
         public void visit(LinkReferenceDefinition linkReferenceDefinition) {
-            log.debug("{}: visit LinkReferenceDefinition", key);
+            log.trace("{}: reject LinkReferenceDefinition", key);
             invalid = true;
         }
 
         @Override
         public void visit(CustomBlock customBlock) {
-            log.debug("{}: visit CustomBlock", key);
+            log.trace("{}: reject CustomBlock", key);
             invalid = true;
         }
 
         @Override
         public void visit(CustomNode customNode) {
-            log.debug("{}: visit CustomNode", key);
+            log.trace("{}: reject CustomNode", key);
             invalid = true;
         }
     }

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -127,7 +127,7 @@ public class NotificationService {
         if (state == state.CASE_STOPPED_CAVEAT) {
             personalisation = caveatPersonalisationService.getCaveatStopPersonalisation(personalisation, caseData);
         }
-        List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
         if (!invalidPersonalisation.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caseDetails.getId(), invalidPersonalisation);
@@ -169,12 +169,14 @@ public class NotificationService {
         String emailReplyToId = registry.getEmailReplyToId();
 
         personalisation.replace(PERSONALISATION_APPLICANT_NAME, executor.getName());
-        List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
         if (!invalidPersonalisation.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caseDetails.getId(), invalidPersonalisation);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
         }
+
         SendEmailResponse response =
             getSendEmailResponse(state, templateId, emailReplyToId, emailAddress, personalisation, reference,
                 caseDetails.getId());
@@ -197,6 +199,14 @@ public class NotificationService {
                 grantOfRepresentationPersonalisationService.getNocPersonalisation(caseDetails.getId(),
                         solicitorName, deceasedName);
         String emailReplyToId = registry.getEmailReplyToId();
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+        if (!invalidPersonalisation.isEmpty()) {
+            log.error("Personalisation validation failed for case: {} fields: {}",
+                    caseDetails.getId(), invalidPersonalisation);
+            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        }
+
         log.info("Personlisation complete now get the email response");
 
         SendEmailResponse response =
@@ -221,6 +231,14 @@ public class NotificationService {
                         CAVEAT_SOLICITOR_NAME, deceasedName);
         String emailReplyToId = registry.getEmailReplyToId();
         String reference = caveatData.getSolsSolicitorAppReference();
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+        if (!invalidPersonalisation.isEmpty()) {
+            log.error("Personalisation validation failed for caveat: {} fields: {}",
+                    caveatDetails.getId(), invalidPersonalisation);
+            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        }
+
         log.info("Personlisation complete now get the email response");
 
         SendEmailResponse response =
@@ -248,7 +266,8 @@ public class NotificationService {
         }
 
         String reference = caveatDetails.getId().toString();
-        List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
         if (!invalidPersonalisation.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caveatDetails.getId(), invalidPersonalisation);
@@ -325,12 +344,14 @@ public class NotificationService {
         grantOfRepresentationPersonalisationService.addSingleAddressee(personalisation, executor.getName());
 
         personalisation.put(PERSONALISATION_SOT_LINK, prepareUpload(sotDocument));
-        List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
         if (!invalidPersonalisation.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caseDetails.getId(), invalidPersonalisation);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
         }
+
         String reference = caseDetails.getData().getSolsSolicitorAppReference();
         String templateId = templateService.getTemplateId(state, caseDetails.getData().getApplicationType(),
                 caseDetails.getData().getRegistryLocation(),
@@ -389,12 +410,14 @@ public class NotificationService {
             registriesProperties.getRegistries().get(caseDetails.getData().getRegistryLocation().toLowerCase());
         Map<String, Object> personalisation =
             grantOfRepresentationPersonalisationService.getPersonalisation(caseDetails, registry);
-        List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<String> invalidPersonalisation = personalisationValidationRule.validatePersonalisation(personalisation);
         if (!invalidPersonalisation.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caseDetails.getId(), invalidPersonalisation);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
         }
+
         String reference = caseDetails.getData().getSolsSolicitorAppReference();
         String emailAddress = caseDetails.getData().getApplicationType().equals(ApplicationType.PERSONAL)
             ? caseDetails.getData().getPrimaryApplicantEmailAddress() : caseDetails.getData().getSolsSolicitorEmail();

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,6 @@ public class PersonalisationValidationRule {
                 }
             }
         }
-        return invalidFields;
+        return Collections.unmodifiableList(invalidFields);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -1,32 +1,35 @@
 package uk.gov.hmcts.probate.validator;
 
 import lombok.RequiredArgsConstructor;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
 public class PersonalisationValidationRule {
 
-    private final Pattern markdownLinkPattern =
-            Pattern.compile("^\\[(.*?)]\\((https?:\\/\\/.*?)\\)$", Pattern.CASE_INSENSITIVE);
+    private final Parser markdownParser;
 
-    public <T> List<String> validatePersonalisation(Map<String, T> personalisation) {
-        List<String> invalidFields = new ArrayList<>();
-        for (var entry : personalisation.entrySet()) {
+    private final MarkdownValidatorService markdownValidatorService;
+
+    public <T> List<String> validatePersonalisation(final Map<String, T> personalisation) {
+        final List<String> invalidFields = new ArrayList<>();
+        for (final var entry : personalisation.entrySet()) {
             if (entry.getValue() != null) {
-                String entryValue = entry.getValue().toString();
-                int firstIndex = entryValue.indexOf('[');
-                int secondIndex = entryValue.indexOf(')');
-                if (firstIndex != -1 && secondIndex != -1 && firstIndex < secondIndex) {
-                    String valueToValidate = entryValue.substring(firstIndex, secondIndex + 1);
-                    if (!valueToValidate.isEmpty() && markdownLinkPattern.matcher(valueToValidate).find()) {
-                        invalidFields.add(entry.getKey());
-                    }
+                final String key = entry.getKey();
+                final String entryValue = entry.getValue().toString();
+                final Node parsed = markdownParser.parse(entryValue);
+
+                MarkdownValidatorService.NontextVisitor nontextVisit = markdownValidatorService.getNontextVisitor(key);
+                parsed.accept(nontextVisit);
+                if (nontextVisit.isInvalid()) {
+                    invalidFields.add(key);
                 }
             }
         }

--- a/src/test/java/uk/gov/hmcts/probate/service/MarkdownValidatorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/MarkdownValidatorServiceTest.java
@@ -1,0 +1,292 @@
+package uk.gov.hmcts.probate.service;
+
+
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.BulletList;
+import org.commonmark.node.Code;
+import org.commonmark.node.CustomBlock;
+import org.commonmark.node.CustomNode;
+import org.commonmark.node.Document;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.OrderedList;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.StrongEmphasis;
+import org.commonmark.node.Text;
+import org.commonmark.node.ThematicBreak;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.probate.service.MarkdownValidatorService.NontextVisitor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class MarkdownValidatorServiceTest {
+
+    @InjectMocks
+    private MarkdownValidatorService markdownValidatorService;
+
+    AutoCloseable closableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closableMocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closableMocks.close();
+    }
+
+    @Test
+    void givenService_whenVisitorRequested_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+
+        assertFalse(visitor.isInvalid(), "Prior to visiting any nodes should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitDocument_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Document node = mock(Document.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting Document should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitBulletList_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final BulletList node = mock(BulletList.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting BulletList should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitHardLineBreak_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final HardLineBreak node = mock(HardLineBreak.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting HardLineBreak should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitHeading_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Heading node = mock(Heading.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting Heading should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitThematicBreak_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final ThematicBreak node = mock(ThematicBreak.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting ThematicBreak should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitListItem_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final ListItem node = mock(ListItem.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting ListItem should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitOrderedList_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final OrderedList node = mock(OrderedList.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting OrderedList should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitParagraph_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Paragraph node = mock(Paragraph.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting Paragraph should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitSoftLineBreak_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final SoftLineBreak node = mock(SoftLineBreak.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting SoftLineBreak should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitText_thenIsNotInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Text node = mock(Text.class);
+
+        visitor.visit(node);
+
+        assertFalse(visitor.isInvalid(), "After visiting Text should not be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitBlockQuote_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final BlockQuote node = mock(BlockQuote.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting BlockQuote should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitCode_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Code node = mock(Code.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting Code should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitEmphasis_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Emphasis node = mock(Emphasis.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting Emphasis should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitFencedCodeBlock_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final FencedCodeBlock node = mock(FencedCodeBlock.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting FencedCodeBlock should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitHtmlInline_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final HtmlInline node = mock(HtmlInline.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting HtmlInline should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitHtmlBlock_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final HtmlBlock node = mock(HtmlBlock.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting HtmlBlock should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitImage_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Image node = mock(Image.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting Image should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitIndentedCodeBlock_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final IndentedCodeBlock node = mock(IndentedCodeBlock.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting IndentedCodeBlock should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitLink_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final Link node = mock(Link.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting Link should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitStrongEmphasis_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final StrongEmphasis node = mock(StrongEmphasis.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting StrongEmphasis should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitLinkReferenceDefinition_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final LinkReferenceDefinition node = mock(LinkReferenceDefinition.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting LinkReferenceDefinition should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitCustomBlock_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final CustomBlock node = mock(CustomBlock.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting CustomBlock should be invalid");
+    }
+
+    @Test
+    void givenVisitor_whenVisitCustomNode_thenIsInvalid() {
+        final NontextVisitor visitor = markdownValidatorService.getNontextVisitor("key");
+        final CustomNode node = mock(CustomNode.class);
+
+        visitor.visit(node);
+
+        assertTrue(visitor.isInvalid(), "After visiting CustomNode should be invalid");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.probate.validator;
 
+import org.commonmark.parser.Parser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,46 +19,81 @@ import java.util.function.Function;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class PersonalisationValidationRuleTest {
+
+    @Spy
+    Parser markdownParserSpy = Parser.builder().build();
+
+    @Spy
+    MarkdownValidatorService markdownValidatorService;
 
     @InjectMocks
     private PersonalisationValidationRule personalisationValidationRule;
 
+    AutoCloseable closableMocks;
+
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        closableMocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closableMocks.close();
     }
 
     @Test
-    void shouldReturnFielNameWithHyperLinkWhereValidatePersonilization() {
+    void givenMixedValidAndInvalidInputs_whenValidated_thenReturnsInvalidFields() {
         final Map<String, Object> personalisation = new HashMap<>();
+
         personalisation.put("valid", "Valid text");
-        personalisation.put("single_link", "Some text [example](http://example.com)");
-        personalisation.put("bypass_using_match_before", "[) [example](http://example.com)");
-        personalisation.put("bypass_with_early_rsqb", "[example]](http://example.com)");
-        personalisation.put("with_bold", "bold **text**");
-        personalisation.put("with_ital", "ital *text*");
-        personalisation.put("with_bold_alt", "bold __text__");
-        personalisation.put("with_ital_alt", "ital _text_");
+
+        // Documented as supported by Notify https://www.notifications.service.gov.uk/using-notify/formatting
         personalisation.put("heading1", "# heading1");
         personalisation.put("heading2", "## heading2");
         personalisation.put("heading1_alt", "heading1\n========");
         personalisation.put("heading2_alt", "heading2\n--------");
-        personalisation.put("blockquote", "> blockquote");
         personalisation.put("list", "* list");
         personalisation.put("list_alt", "- list");
         personalisation.put("numlist", "1. list");
         personalisation.put("numlist_alt", "1) list");
         personalisation.put("hrule", "---");
         personalisation.put("hrule_alt", "***");
+
+        // Documented as unsupported by Notify
+        personalisation.put("with_bold", "bold **text**");
+        personalisation.put("with_ital", "ital *text*");
+        personalisation.put("with_bold_alt", "bold __text__");
+        personalisation.put("with_ital_alt", "ital _text_");
         personalisation.put("inline_code", "`inline code`");
         personalisation.put("code_block", "```\ncode\nblock\n```");
         personalisation.put("code_block_alt", "    code\n    block");
 
+        // Not explicitly documented as supported or unsupported (the documentation refers to "inset text"
+        // but uses: " ^ inset text" as the example. Unclear if this is just a nonstandard alternative, but
+        // a stock markdown implementation will not catch it. This is likely because `>` would be removed
+        // by any html filtering.
+        personalisation.put("block_quote", "> block_quote");
+
+        // Link handling
+        personalisation.put("single_link", "Some text [example](http://example.com)");
+        personalisation.put("bypass_using_match_before", "[) [example](http://example.com)");
+        personalisation.put("bypass_with_early_rsqb", "[example\\]](http://example.com)");
+        personalisation.put("link_with_ref", "Some text [link][1]\n\nMore text\n\n[1]: http://example.com");
+
+        // Images (not mentioned in Notify documentation, but seems like we shouldn't be permitting this
+        personalisation.put("single_image", "Some text ![example](http://example.com/img.png)");
+        personalisation.put("image_with_ref", "Some text ![link][1]\n\nMore text\n\n[1]: http://example.com/img.png");
+
+
         final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
 
-        final Function<String, Executable> assertContains = (name) -> {
+        final Function<String, Executable> assertContains = name -> {
             return () -> assertTrue(result.contains(name), "result did not contain " + name);
         };
 
@@ -66,6 +105,45 @@ class PersonalisationValidationRuleTest {
             }
         }
 
+        assertAll(assertions);
+    }
+
+    @Test
+    void givenInput_whenValidatorFlags_thenRejected() {
+        final var key = "key";
+        final var personalisation = Map.ofEntries(Map.entry(key, "value"));
+
+        final var visitorMock = mock(MarkdownValidatorService.NontextVisitor.class);
+        when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
+        when(visitorMock.isInvalid()).thenReturn(true);
+
+        final var result = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<Executable> assertions = List.of(
+                () -> verify(markdownValidatorService).getNontextVisitor(any()),
+                () -> verify(visitorMock).isInvalid(),
+                () -> assertEquals(1, result.size(), "Expected validation to fail"),
+                () -> assertTrue(result.contains(key), "Expected key to be present in failure list")
+        );
+        assertAll(assertions);
+    }
+
+    @Test
+    void givenInput_whenValidatorPasses_thenAccepted() {
+        final var key = "key";
+        final var personalisation = Map.ofEntries(Map.entry(key, "value"));
+
+        final var visitorMock = mock(MarkdownValidatorService.NontextVisitor.class);
+        when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
+        when(visitorMock.isInvalid()).thenReturn(false);
+
+        final var result = personalisationValidationRule.validatePersonalisation(personalisation);
+
+        final List<Executable> assertions = List.of(
+                () -> verify(markdownValidatorService).getNontextVisitor(any()),
+                () -> verify(visitorMock).isInvalid(),
+                () -> assertEquals(0, result.size(), "Expected validation to pass")
+        );
         assertAll(assertions);
     }
 

--- a/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
@@ -2,13 +2,17 @@ package uk.gov.hmcts.probate.validator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,14 +28,45 @@ class PersonalisationValidationRuleTest {
 
     @Test
     void shouldReturnFielNameWithHyperLinkWhereValidatePersonilization() {
-        Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("field1", "Some text [example](http://example.com)");
-        personalisation.put("field2", "Valid text");
+        final Map<String, Object> personalisation = new HashMap<>();
+        personalisation.put("valid", "Valid text");
+        personalisation.put("single_link", "Some text [example](http://example.com)");
+        personalisation.put("bypass_using_match_before", "[) [example](http://example.com)");
+        personalisation.put("bypass_with_early_rsqb", "[example]](http://example.com)");
+        personalisation.put("with_bold", "bold **text**");
+        personalisation.put("with_ital", "ital *text*");
+        personalisation.put("with_bold_alt", "bold __text__");
+        personalisation.put("with_ital_alt", "ital _text_");
+        personalisation.put("heading1", "# heading1");
+        personalisation.put("heading2", "## heading2");
+        personalisation.put("heading1_alt", "heading1\n========");
+        personalisation.put("heading2_alt", "heading2\n--------");
+        personalisation.put("blockquote", "> blockquote");
+        personalisation.put("list", "* list");
+        personalisation.put("list_alt", "- list");
+        personalisation.put("numlist", "1. list");
+        personalisation.put("numlist_alt", "1) list");
+        personalisation.put("hrule", "---");
+        personalisation.put("hrule_alt", "***");
+        personalisation.put("inline_code", "`inline code`");
+        personalisation.put("code_block", "```\ncode\nblock\n```");
+        personalisation.put("code_block_alt", "    code\n    block");
 
-        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
+        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
 
-        assertEquals(1, result.size());
-        assertTrue(result.contains("field1"));
+        final Function<String, Executable> assertContains = (name) -> {
+            return () -> assertTrue(result.contains(name), "result did not contain " + name);
+        };
+
+        final List<Executable> assertions = new ArrayList<Executable>();
+        assertions.add(() -> assertEquals(personalisation.size() - 1, result.size(), "Did not identify all issues"));
+        for (String key : personalisation.keySet()) {
+            if (!key.equals("valid")) {
+                assertions.add(assertContains.apply(key));
+            }
+        }
+
+        assertAll(assertions);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPB-4380

### Change description ###
Changes the approach from a minimal regular expression which permitted a number of inputs to pass filtering which probably should not have to actually use the commonmark parser and then using a visitor across the resulting document tree to identify any problem nodes. We permit non-input consuming items to pass through which leaves the possibility that the document will render in weird or unexpected ways, but no content should be hidden.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```
It's arguable this is a breaking change on the implementation side - things which could previously have been sent will no longer be able to pass this validation. This may be fine if we are not expecting these things to ever actually have been passed and them getting through was an error, but as mentioned above may be important for our processing.
