### PR TITLE
DTSPB-4384 Modify concealment used for values in logs.

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/EmailValidationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/EmailValidationService.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.probate.service;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Base64;
 import java.util.regex.Pattern;
 
 import static uk.gov.hmcts.probate.model.Constants.EMAIL_REGEX;
@@ -27,13 +27,19 @@ public class EmailValidationService {
 
         if (!Pattern.compile(EMAIL_REGEX, Pattern.CASE_INSENSITIVE).matcher(emailAddress).matches()) {
             log.info("Notification not sent due to invalid email address: {}",
-                getEmailEncodedBase64(emailAddress));
+                getHashedEmail(emailAddress));
             return false;
         }
         return true;
     }
 
-    private String getEmailEncodedBase64(String emailAddress) {
-        return new String(Base64.getEncoder().encode(emailAddress.getBytes()));
+    public String getHashedEmail(final String emailAddress) {
+        final String digest = DigestUtils.sha256Hex(emailAddress);
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("SHA-256[");
+        builder.append(digest);
+        builder.append("]");
+        return builder.toString();
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/EmailWithFileService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/EmailWithFileService.java
@@ -28,17 +28,19 @@ public class EmailWithFileService {
 
     private final NotificationClient notificationClient;
 
+    private final EmailAddresses emailAddresses;
+
+    private final EmailValidationService emailValidationService;
+
     @Value("${extract.templates.hmrcExtract}")
     private String templateId;
-
-    @Autowired
-    private final EmailAddresses emailAddresses;
 
     public boolean emailFile(File file, String date) {
         if (null == file || !file.exists()) {
             log.error("Error HMRC file does not exist");
             return false;
         }
+
 
         byte[] fileContents;
         try {
@@ -78,8 +80,9 @@ public class EmailWithFileService {
                     null,
                     null);
                 if (null != response) {
-                    log.info("HMRC email to: {} response: {}",
-                        new String(Base64.getEncoder().encode(email.getBytes())),response.toString());
+                    log.info("HMRC email to: {} notificationId: {}",
+                            emailValidationService.getHashedEmail(email),
+                            response.getNotificationId());
                 }
             }
         } catch (NotificationClientException e) {

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationClientService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationClientService.java
@@ -7,7 +7,6 @@ import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 
-import java.util.Base64;
 import java.util.Map;
 
 @Slf4j
@@ -15,12 +14,13 @@ import java.util.Map;
 @Component
 public class NotificationClientService {
 
+    private final EmailValidationService emailValidationService;
     private final NotificationClient notificationClient;
 
     public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, ?> personalisation,
                                        String reference)
         throws NotificationClientException {
-        log.info("Preparing to send email to email address: {}", getEmailEncodedBase64(emailAddress));
+        log.info("Preparing to send email to email address: {}", emailValidationService.getHashedEmail(emailAddress));
         return notificationClient.sendEmail(templateId, emailAddress, personalisation, reference);
     }
 
@@ -28,7 +28,7 @@ public class NotificationClientService {
                                        Map<String, ?> personalisation, String reference)
         throws NotificationClientException {
         log.info("Preparing to send email for case: {}, to email address: {}", caseID,
-            getEmailEncodedBase64(emailAddress));
+                emailValidationService.getHashedEmail(emailAddress));
         return notificationClient.sendEmail(templateId, emailAddress, personalisation, reference);
     }
 
@@ -36,12 +36,8 @@ public class NotificationClientService {
                                        Map<String, ?> personalisation, String reference, String emailReplyToId)
         throws NotificationClientException {
         log.info("Preparing to send email for case: {}, to email address: {}", caseId,
-            getEmailEncodedBase64(emailAddress));
+                emailValidationService.getHashedEmail(emailAddress));
         return notificationClient.sendEmail(templateId, emailAddress, personalisation, reference, emailReplyToId);
-    }
-
-    private String getEmailEncodedBase64(String emailAddress) {
-        return new String(Base64.getEncoder().encode(emailAddress.getBytes()));
     }
 
 }


### PR DESCRIPTION
It's unclear whether we actually need these values in the logs, but certainly having them not be directly reversible seems prudent.

### JIRA link (if applicable) ###
DTSPB-4384 


### Change description ###
Change from using base64 encoding to a hash in our logs.  We're using it purely as a one-way function so the cryptographic properties aren't strictly relevant.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
