### PR TITLE
DTSBP-4387 Clear primaryApplicant fields when changing from None of These to another titleAndClearingType

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/model/Constants.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/Constants.java
@@ -74,6 +74,7 @@ public final class Constants {
     public static final String TITLE_AND_CLEARING_PARTNER_OTHERS_RENOUNCING = "TCTPartOthersRenouncing";
     public static final String TITLE_AND_CLEARING_PARTNER_SUCC_ALL_RENOUNCING = "TCTPartSuccAllRenouncing";
     public static final String TITLE_AND_CLEARING_PARTNER_ALL_RENOUNCING = "TCTPartAllRenouncing";
+    public static final String TITLE_AND_CLEARING_NONE_OF_THESE = "TCTNoT";
     public static final String REASON_FOR_NOT_APPLYING_RENUNCIATION = "Renunciation";
     public static final String REASON_FOR_NOT_APPLYING_MENTALLY_INCAPABLE = "MentallyIncapable";
     public static final String REASON_FOR_NOT_APPLYING_DIED_BEFORE = "DiedBefore";

--- a/src/main/java/uk/gov/hmcts/probate/model/Constants.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/Constants.java
@@ -35,7 +35,7 @@ public final class Constants {
     public static final String DOC_TYPE_CHERISHED = "cherished";
     public static final String DOC_TYPE_OTHER = "other";
     public static final String DATE_OF_DEATH_TYPE_DEFAULT = "diedOn";
-    public static final String CASE_TYPE_DEFAULT = "gop";
+    public static final String CASE_TYPE_GRANT_OF_PROBATE = "gop";
     public static final String DOCMOSIS_OUTPUT_PDF = "pdf";
     public static final String DOCMOSIS_OUTPUT_HTML = "html";
     public static final String REDEC_NOTIFICATION_SENT_STATE = "BORedecNotificationSent";

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.probate.controller.validation.AmendCaseDetailsGroup;
 import uk.gov.hmcts.probate.controller.validation.ApplicationAdmonGroup;
 import uk.gov.hmcts.probate.controller.validation.ApplicationCreatedGroup;
@@ -73,6 +74,7 @@ import static uk.gov.hmcts.probate.model.Constants.YES;
 @Jacksonized
 @EqualsAndHashCode(callSuper = true)
 @Data
+@Slf4j
 public class CaseData extends CaseDataParent {
 
     // Tasklist update
@@ -696,6 +698,24 @@ public class CaseData extends CaseDataParent {
 
     public boolean isLanguagePreferenceWelsh() {
         return YES.equals(getLanguagePreferenceWelsh());
+    }
+
+    public void clearPrimaryApplicant() {
+        log.debug("Clearing primary applicant information from CaseData");
+
+
+        this.setPrimaryApplicantIsApplying(null);
+
+        this.setPrimaryApplicantForenames(null);
+        this.setPrimaryApplicantSurname(null);
+
+        this.setPrimaryApplicantHasAlias(null);
+        this.setPrimaryApplicantAlias(null);
+
+        this.setPrimaryApplicantAddress(null);
+
+        this.setPrimaryApplicantEmailAddress(null);
+        this.setPrimaryApplicantPhoneNumber(null);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -68,6 +68,7 @@ import java.util.List;
 
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.YES;
+import static uk.gov.hmcts.probate.transformer.CallbackResponseTransformer.ANSWER_NO;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @SuperBuilder
@@ -709,10 +710,16 @@ public class CaseData extends CaseDataParent {
         this.setPrimaryApplicantForenames(null);
         this.setPrimaryApplicantSurname(null);
 
-        this.setPrimaryApplicantHasAlias(null);
+        // This is to be consistent with the behaviour currently exhibited by the service when creating
+        // a case with a non-NoneOfThese TitleAndClearingType.
+        this.setPrimaryApplicantHasAlias(ANSWER_NO);
         this.setPrimaryApplicantAlias(null);
 
-        this.setPrimaryApplicantAddress(null);
+
+        // As above this is to be consistent with the behaviour currently exhibited by the service when
+        // creating a case with a non-NoneOfThese TitleAndClearingType.
+        final SolsAddress nullAddress = SolsAddress.builder().build();
+        this.setPrimaryApplicantAddress(nullAddress);
 
         this.setPrimaryApplicantEmailAddress(null);
         this.setPrimaryApplicantPhoneNumber(null);

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CaseDataTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CaseDataTransformer.java
@@ -56,7 +56,12 @@ public class CaseDataTransformer {
 
 
     public void transformCaseDataForValidateProbate(CallbackRequest callbackRequest) {
-        final var caseData = callbackRequest.getCaseDetails().getData();
+        final var caseDetails = callbackRequest.getCaseDetails();
+        final var caseData = caseDetails.getData();
+
+        solicitorApplicationCompletionTransformer.clearPrimaryApplicantWhenNotInNoneOfTheseTitleAndClearingType(
+                caseDetails);
+
         resetCaseDataTransformer.resetExecutorLists(caseData);
         solicitorApplicationCompletionTransformer.setFieldsIfSolicitorIsNotNamedInWillAsAnExecutor(caseData);
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static uk.gov.hmcts.probate.model.ApplicationState.CASE_PRINTED;
+import static uk.gov.hmcts.probate.model.Constants.CASE_TYPE_GRANT_OF_PROBATE;
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_NONE_OF_THESE;
 
@@ -76,13 +77,19 @@ public class SolicitorApplicationCompletionTransformer extends LegalStatementExe
             final var caseId = caseDetails.getId();
             final var caseData = caseDetails.getData();
 
-            final var titleAndClearingType = caseDetails.getData().getTitleAndClearingType();
-            final var primaryApplicantApplying = caseData.isPrimaryApplicantApplying();
+            final var titleAndClearingType = caseData.getTitleAndClearingType();
+            final var caseType = caseData.getCaseType();
 
-            if ((!TITLE_AND_CLEARING_NONE_OF_THESE.equalsIgnoreCase(titleAndClearingType))
-                    && primaryApplicantApplying) {
-                log.info("In case {} we have primary applicant applying for non-NoneOfThese TitleAndClearingType {},"
-                                + " clear PrimaryApplicant fields",
+            final var primaryApplicantApplying = caseData.isPrimaryApplicantApplying();
+            final var isNotNoneOfTheseTCT = titleAndClearingType != null
+                    && !TITLE_AND_CLEARING_NONE_OF_THESE.equalsIgnoreCase(titleAndClearingType);
+            final var isGrantOfProbate = CASE_TYPE_GRANT_OF_PROBATE.equalsIgnoreCase(caseType);
+
+            if (isNotNoneOfTheseTCT
+                    && primaryApplicantApplying
+                    && isGrantOfProbate) {
+                log.info("In GrantOfProbate case {} we have primary applicant applying for non-NoneOfThese "
+                        + "TitleAndClearingType {}, clear PrimaryApplicant fields",
                         caseId,
                         titleAndClearingType);
 

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static uk.gov.hmcts.probate.model.ApplicationState.CASE_PRINTED;
 import static uk.gov.hmcts.probate.model.Constants.NO;
+import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_NONE_OF_THESE;
 
 @Component
 @Slf4j
@@ -61,6 +62,23 @@ public class SolicitorApplicationCompletionTransformer extends LegalStatementExe
         if (totalAmount.compareTo(BigDecimal.ZERO) == 0) {
             caseDetails.getData().setPaymentTaken(NOT_APPLICABLE);
             caseDetails.setState(CASE_PRINTED.getId());
+        }
+    }
+
+    public void clearPrimaryApplicantWhenNotInNoneOfTheseTitleAndClearingType(CaseDetails caseDetails) {
+        final var caseId = caseDetails.getId();
+        final var caseData = caseDetails.getData();
+
+        final var titleAndClearingType = caseDetails.getData().getTitleAndClearingType();
+        final var primaryApplicantApplying = caseData.isPrimaryApplicantApplying();
+
+        if ((!TITLE_AND_CLEARING_NONE_OF_THESE.equalsIgnoreCase(titleAndClearingType)) && primaryApplicantApplying) {
+            log.info("In case {} we have primary applicant applying for non-NoneOfThese TitleAndClearingType {},"
+                            + " clear PrimaryApplicant fields",
+                    caseId,
+                    titleAndClearingType);
+
+            caseData.clearPrimaryApplicant();
         }
     }
 }

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="uk.gov.hmcts.probate.service.MarkdownValidatorService" level="TRACE" />
+</configuration>

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.probate.model.ccd.raw.request;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -92,10 +93,12 @@ class CaseDataTest {
 
     private CaseData underTest;
 
+    private AutoCloseable closeableMocks;
+
     @BeforeEach
     public void setup() {
 
-        openMocks(this);
+        closeableMocks = openMocks(this);
 
         when(additionalExecutors1Mock.getValue()).thenReturn(additionalExecutor1Mock);
         when(additionalExecutors2Mock.getValue()).thenReturn(additionalExecutor2Mock);
@@ -134,6 +137,11 @@ class CaseDataTest {
             .solsAdditionalExecutorList(additionalExecutorsList)
             .otherExecutorExists(YES)
             .build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
     }
 
     @Test
@@ -952,5 +960,38 @@ class CaseDataTest {
         assertEquals("9/2021", caseData.getCodicilsDamageDate());
 
         assertEquals("Yes", caseData.getDeceasedWrittenWishes());
+    }
+
+    @Test
+    void clearPrimaryApplicantClearsPrimaryApplicant() {
+        final CaseData.CaseDataBuilder caseDataBuilder = CaseData.builder();
+
+        final CaseData baseCaseData = caseDataBuilder.build();
+
+        final SolsAddress applAddress = SolsAddress.builder()
+                .addressLine1("addr1")
+                .addressLine2("addr2")
+                .addressLine3("addr3")
+                .country("country")
+                .county("county")
+                .postCode("postcode")
+                .postTown("town")
+                .build();
+
+        final CaseData applCaseData =  caseDataBuilder
+                .primaryApplicantIsApplying("yes")
+                .primaryApplicantHasAlias("yes")
+                .primaryApplicantForenames("fname")
+                .primaryApplicantSurname("sname")
+                .primaryApplicantHasAlias("yes")
+                .primaryApplicantAlias("alias")
+                .primaryApplicantEmailAddress("email")
+                .primaryApplicantPhoneNumber("phone")
+                .primaryApplicantAddress(applAddress)
+                .build();
+
+        applCaseData.clearPrimaryApplicant();
+
+        assertEquals(baseCaseData, applCaseData);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseDataTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.YES;
+import static uk.gov.hmcts.probate.transformer.CallbackResponseTransformer.ANSWER_NO;
 
 class CaseDataTest {
 
@@ -964,7 +965,11 @@ class CaseDataTest {
 
     @Test
     void clearPrimaryApplicantClearsPrimaryApplicant() {
-        final CaseData.CaseDataBuilder caseDataBuilder = CaseData.builder();
+        final SolsAddress nullAddress = SolsAddress.builder().build();
+
+        final CaseData.CaseDataBuilder caseDataBuilder = CaseData.builder()
+                .primaryApplicantHasAlias(ANSWER_NO)
+                .primaryApplicantAddress(nullAddress);
 
         final CaseData baseCaseData = caseDataBuilder.build();
 

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
@@ -16,17 +16,23 @@ import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.response.ResponseCaseData;
+import uk.gov.hmcts.probate.service.DateFormatterService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_SOLE_PRINCIPLE;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_TRUST_CORP;
@@ -245,26 +251,37 @@ class ExecutorsTransformerTest {
         assertEquals(SOLICITOR_NOT_APPLYING_REASON, cd.getSolsSolicitorNotApplyingReason());
     }
 
-    // Why is this test here? what is it testing? (? ExecutorListMapperService ?)
-    /*
+    /* Should this test be in this Test class? It's testing a subclass and is really relying on a third
+     * service (ExecutorListMapperService) to do most of the work here.
+     */
     @Test
     void shouldSwapSolicitorToNotApplyingList() {
-        caseDataBuilder
+        final CaseData caseData = CaseData.builder()
                 .additionalExecutorsApplying(additionalExecutorApplying)
                 .additionalExecutorsNotApplying(additionalExecutorNotApplying)
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
-                .primaryApplicantForenames(EXEC_FIRST_NAME);
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .build();
 
-        final CaseData cd = caseDataBuilder.build();
+        final var executorListMapperSpy = spy(ExecutorListMapperService.class);
 
-        new SolicitorApplicationCompletionTransformer(new ExecutorListMapperService(), new DateFormatterService())
-                .mapSolicitorExecutorFieldsOnCompletion(cd);
+        // We only need these to construct the SolicitorXformer object, we verifyNoInteractions to confirm
+        final var dateFormatterMock = mock(DateFormatterService.class);
+        final var featureToggleMock = mock(FeatureToggleService.class);
 
-        assertEquals(0, cd.getAdditionalExecutorsApplying().size());
-        assertEquals(1, cd.getAdditionalExecutorsNotApplying().size());
+        final var solXformer = new SolicitorApplicationCompletionTransformer(
+                executorListMapperSpy,
+                dateFormatterMock,
+                featureToggleMock);
+        solXformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
+
+        assertAll(
+                () -> assertEquals(0, caseData.getAdditionalExecutorsApplying().size()),
+                () -> assertEquals(1, caseData.getAdditionalExecutorsNotApplying().size()),
+                () -> verifyNoInteractions(dateFormatterMock, featureToggleMock)
+        );
     }
-     */
 
     @Test
     void shouldSetCaseworkerExecutorListsAsEmpty() {

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.response.ResponseCaseData;
-import uk.gov.hmcts.probate.service.DateFormatterService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.util.ArrayList;
@@ -246,6 +245,8 @@ class ExecutorsTransformerTest {
         assertEquals(SOLICITOR_NOT_APPLYING_REASON, cd.getSolsSolicitorNotApplyingReason());
     }
 
+    // Why is this test here? what is it testing? (? ExecutorListMapperService ?)
+    /*
     @Test
     void shouldSwapSolicitorToNotApplyingList() {
         caseDataBuilder
@@ -263,6 +264,7 @@ class ExecutorsTransformerTest {
         assertEquals(0, cd.getAdditionalExecutorsApplying().size());
         assertEquals(1, cd.getAdditionalExecutorsNotApplying().size());
     }
+     */
 
     @Test
     void shouldSetCaseworkerExecutorListsAsEmpty() {

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -56,9 +56,6 @@ import static uk.gov.hmcts.probate.util.CommonVariables.YES;
 class SolicitorApplicationCompletionTransformerTest {
 
     @Mock
-    private CaseDetails caseDetailsMock;
-
-    @Mock
     private DateFormatterService dateFormatterServiceMock;
 
     @Mock
@@ -113,8 +110,7 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo() {
-
-        CaseData caseData = CaseData.builder()
+        final CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(YES)
                 .titleAndClearingType(TITLE_AND_CLEARING_TRUST_CORP)
@@ -134,7 +130,8 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithNotApplyingExecutorInfo() {
-        CaseData caseData = CaseData.builder()
+        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
+        final CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
                 .additionalExecutorsTrustCorpList(null)
@@ -160,7 +157,8 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantApplying() {
-        CaseData caseData = CaseData.builder()
+        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
+        final CaseData caseData = CaseData.builder()
                 .primaryApplicantForenames(EXEC_FIRST_NAME)
                 .primaryApplicantSurname(EXEC_SURNAME)
                 .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
@@ -180,7 +178,8 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantNotApplying() {
-        CaseData caseData = CaseData.builder()
+        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
+        final CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
                 .solsSolicitorIsExec(YES)
@@ -199,7 +198,8 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfoYesNo() {
-        CaseData caseData = CaseData.builder()
+        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
+        final CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
                 .solsSolicitorIsExec(YES)
@@ -224,7 +224,7 @@ class SolicitorApplicationCompletionTransformerTest {
         final List<CollectionMember<String>> formattedDate =
                 Arrays.asList(new CollectionMember<>("Formatted Date"));
 
-        CaseData caseData = CaseData.builder()
+        final CaseData caseData = CaseData.builder()
                 .willHasCodicils(NO)
                 .codicilAddedDateList(codicilDates)
                 .codicilAddedFormattedDateList(formattedDate)
@@ -238,9 +238,9 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetServiceRequest() {
-        BigDecimal totalAmount = BigDecimal.valueOf(100000);
-        CaseData caseData = CaseData.builder().build();
-        CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
+        final BigDecimal totalAmount = BigDecimal.valueOf(100000);
+        final CaseData caseData = CaseData.builder().build();
+        final CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
         solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 
         assertNull(caseData.getPaymentTaken());
@@ -248,9 +248,9 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetPaymentTakenNotApplicableWhenNoServiceRequest() {
-        BigDecimal totalAmount = BigDecimal.ZERO;
-        CaseData caseData = CaseData.builder().build();
-        CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
+        final BigDecimal totalAmount = BigDecimal.ZERO;
+        final CaseData caseData = CaseData.builder().build();
+        final CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
         solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 
         assertEquals(NOT_APPLICABLE, caseData.getPaymentTaken());

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -27,14 +27,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_NONE_OF_THESE;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_TRUST_CORP;
@@ -55,8 +54,6 @@ import static uk.gov.hmcts.probate.util.CommonVariables.YES;
 
 @ExtendWith(SpringExtension.class)
 class SolicitorApplicationCompletionTransformerTest {
-
-    private final CaseData.CaseDataBuilder<?, ?> caseDataBuilder = CaseData.builder();
 
     @Mock
     private CaseDetails caseDetailsMock;
@@ -117,15 +114,14 @@ class SolicitorApplicationCompletionTransformerTest {
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo() {
 
-        caseDataBuilder
+        CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(YES)
                 .titleAndClearingType(TITLE_AND_CLEARING_TRUST_CORP)
                 .anyOtherApplyingPartnersTrustCorp(YES)
                 .additionalExecutorsTrustCorpList(trustCorpsExecutorList)
-                .solsAdditionalExecutorList(solsAdditionalExecutorList);
-
-        CaseData caseData = caseDataBuilder.build();
+                .solsAdditionalExecutorList(solsAdditionalExecutorList)
+                .build();
 
         SolicitorApplicationCompletionTransformer solJourneyCompletion =
             new SolicitorApplicationCompletionTransformer(new ExecutorListMapperService(), new DateFormatterService());
@@ -138,15 +134,14 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithNotApplyingExecutorInfo() {
-        caseDataBuilder
+        CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
                 .additionalExecutorsTrustCorpList(null)
                 .otherPartnersApplyingAsExecutors(null)
                 .dispenseWithNoticeOtherExecsList(dispenseWithNoticeExecList)
-                .solsAdditionalExecutorList(solsAdditionalExecutorList);
-
-        CaseData caseData = caseDataBuilder.build();
+                .solsAdditionalExecutorList(solsAdditionalExecutorList)
+                .build();
 
         when(caseDetailsMock.getData()).thenReturn(caseData);
         when(executorListMapperServiceMock.mapFromDispenseWithNoticeExecsToNotApplyingExecutors(
@@ -165,18 +160,18 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantApplying() {
-        caseDataBuilder
-            .primaryApplicantForenames(EXEC_FIRST_NAME)
-            .primaryApplicantSurname(EXEC_SURNAME)
-            .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
-            .primaryApplicantAddress(EXEC_ADDRESS)
-            .primaryApplicantIsApplying(YES);
+        CaseData caseData = CaseData.builder()
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .primaryApplicantSurname(EXEC_SURNAME)
+                .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
+                .primaryApplicantAddress(EXEC_ADDRESS)
+                .primaryApplicantIsApplying(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        when(caseDetailsMock.getData()).thenReturn(caseData);
         when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
                 caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
         assertEquals(additionalExecutorApplying, caseData.getExecutorsApplyingLegalStatement());
@@ -185,17 +180,17 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantNotApplying() {
-        caseDataBuilder
+        CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
-                .solsSolicitorIsExec(YES);
+                .solsSolicitorIsExec(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        when(caseDetailsMock.getData()).thenReturn(caseData);
         when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
                 caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
                     ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
         assertEquals(additionalExecutorNotApplying, caseData.getExecutorsNotApplyingLegalStatement());
@@ -204,17 +199,17 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfoYesNo() {
-        caseDataBuilder
-            .primaryApplicantIsApplying(NO)
-            .solsSolicitorIsApplying(NO)
-            .solsSolicitorIsExec(YES);
+        CaseData caseData = CaseData.builder()
+                .primaryApplicantIsApplying(NO)
+                .solsSolicitorIsApplying(NO)
+                .solsSolicitorIsExec(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
+        when(caseDetailsMock.getData()).thenReturn(caseData);
         when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
             caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
             ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);
 
         assertEquals(additionalExecutorNotApplying, caseData.getExecutorsNotApplyingLegalStatement());
@@ -228,12 +223,13 @@ class SolicitorApplicationCompletionTransformerTest {
                         .dateCodicilAdded(LocalDate.now().minusDays(1)).build()));
         final List<CollectionMember<String>> formattedDate =
                 Arrays.asList(new CollectionMember<>("Formatted Date"));
-        caseDataBuilder
+
+        CaseData caseData = CaseData.builder()
                 .willHasCodicils(NO)
                 .codicilAddedDateList(codicilDates)
-                .codicilAddedFormattedDateList(formattedDate);
+                .codicilAddedFormattedDateList(formattedDate)
+                .build();
 
-        CaseData caseData = caseDataBuilder.build();
         solicitorApplicationCompletionTransformer.eraseCodicilAddedDateIfWillHasNoCodicils(caseData);
 
         assertNull(caseData.getCodicilAddedDateList());
@@ -243,7 +239,7 @@ class SolicitorApplicationCompletionTransformerTest {
     @Test
     void shouldSetServiceRequest() {
         BigDecimal totalAmount = BigDecimal.valueOf(100000);
-        CaseData caseData = caseDataBuilder.build();
+        CaseData caseData = CaseData.builder().build();
         CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
         solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 
@@ -253,7 +249,7 @@ class SolicitorApplicationCompletionTransformerTest {
     @Test
     void shouldSetPaymentTakenNotApplicableWhenNoServiceRequest() {
         BigDecimal totalAmount = BigDecimal.ZERO;
-        CaseData caseData = caseDataBuilder.build();
+        CaseData caseData = CaseData.builder().build();
         CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
         solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -3,11 +3,9 @@ package uk.gov.hmcts.probate.transformer.solicitorexecutors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutor;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutorApplying;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutorNotApplying;
@@ -52,7 +50,6 @@ import static uk.gov.hmcts.probate.util.CommonVariables.SOLS_EXEC_ADDITIONAL_APP
 import static uk.gov.hmcts.probate.util.CommonVariables.SOLS_EXEC_NOT_APPLYING;
 import static uk.gov.hmcts.probate.util.CommonVariables.YES;
 
-@ExtendWith(SpringExtension.class)
 class SolicitorApplicationCompletionTransformerTest {
 
     @Mock

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -157,7 +157,6 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantApplying() {
-        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
         final CaseData caseData = CaseData.builder()
                 .primaryApplicantForenames(EXEC_FIRST_NAME)
                 .primaryApplicantSurname(EXEC_SURNAME)
@@ -166,9 +165,9 @@ class SolicitorApplicationCompletionTransformerTest {
                 .primaryApplicantIsApplying(YES)
                 .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseData);
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
-                caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_APPLYING));
+
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_APPLYING));
 
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
@@ -178,17 +177,14 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantNotApplying() {
-        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
         final CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
                 .solsSolicitorIsExec(YES)
                 .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseData);
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
-                caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
-                    ADDITIONAL_EXECUTOR_NOT_APPLYING));
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
@@ -198,17 +194,15 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfoYesNo() {
-        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
         final CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
                 .solsSolicitorIsExec(YES)
                 .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseData);
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
-            caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
-            ADDITIONAL_EXECUTOR_NOT_APPLYING));
+
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);
 

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -247,6 +247,11 @@ class SolicitorApplicationCompletionTransformerTest {
         assertEquals(NOT_APPLICABLE, caseData.getPaymentTaken());
     }
 
+    // given Case
+    // and TitleClearingType is not NoneOfThese
+    // and PrimaryApplicantApplying is true
+    // when transformer clearPrimaryForNoneOfThese called
+    // then primaryApplicantClear is called
     @Test
     void givenCaseWithoutNoneOfTheseTitleClearingTypeANDPrimaryApplicant_whenChecked_thenPrimaryApplicantDataCleared() {
         final CaseData caseData = mock(CaseData.class);
@@ -261,6 +266,11 @@ class SolicitorApplicationCompletionTransformerTest {
         verify(caseData, times(1)).clearPrimaryApplicant();
     }
 
+    // given Case
+    // and TitleClearingType is NoneOfThese
+    // and PrimaryApplicantApplying is true
+    // when transformer clearPrimaryForNoneOfThese called
+    // then primaryApplicantClear is not called
     @Test
     void givenCaseWithNoneOfTheseTitleClearingTypeANDPrimaryApplicant_whenChecked_thenPrimaryApplicantDataNOTCleared() {
         final CaseData caseData = mock(CaseData.class);
@@ -275,8 +285,13 @@ class SolicitorApplicationCompletionTransformerTest {
         verify(caseData, times(0)).clearPrimaryApplicant();
     }
 
+    // given Case
+    // and TitleClearingType is not NoneOfThese
+    // and PrimaryApplicantApplying is false
+    // when transformer clearPrimaryForNoneOfThese called
+    // then primaryApplicantClear is not called
     @Test
-    void givenCaseWithoutNoneOfTheseTitleClearingTypeANDWithoutPrimaryApplicant_whenChecked_thenPrimaryApplicantDataNOTCleared() {
+    void givenCaseWoutNoneOfTheseTitleClearingTypeANDWoutPrmryApplicant_whenChecked_thenPrmryApplicantDataNOTCleared() {
         final CaseData realCaseData = CaseData.builder().build();
         final CaseData spyCaseData = spy(realCaseData);
         final CaseDetails caseDetails = new CaseDetails(spyCaseData, null, 0L);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.probate.model.Constants.CASE_TYPE_GRANT_OF_PROBATE;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_NONE_OF_THESE;
 import static uk.gov.hmcts.probate.util.CommonVariables.ADDITIONAL_EXECUTOR_APPLYING;
 import static uk.gov.hmcts.probate.util.CommonVariables.ADDITIONAL_EXECUTOR_NOT_APPLYING;
@@ -254,6 +255,7 @@ class SolicitorApplicationCompletionTransformerTest {
     }
 
     // given Case
+    // and CaseType is GrantOfProbate
     // and TitleClearingType is not NoneOfThese
     // and PrimaryApplicantApplying is true
     // when transformer clearPrimaryForNoneOfThese called
@@ -265,6 +267,7 @@ class SolicitorApplicationCompletionTransformerTest {
 
         when(featureToggleServiceMock.enableDuplicateExecutorFiltering()).thenReturn(true);
 
+        when(caseData.getCaseType()).thenReturn(CASE_TYPE_GRANT_OF_PROBATE);
         when(caseData.getTitleAndClearingType()).thenReturn("");
         when(caseData.isPrimaryApplicantApplying()).thenReturn(true);
 
@@ -275,6 +278,30 @@ class SolicitorApplicationCompletionTransformerTest {
     }
 
     // given Case
+    // and CaseType is NOT GrantOfProbate
+    // and TitleClearingType is not NoneOfThese
+    // and PrimaryApplicantApplying is true
+    // when transformer clearPrimaryForNoneOfThese called
+    // then primaryApplicantClear is NOT called
+    @Test
+    void givenCaseNotGOPWoutNoneOfTheseTCTypeANDPrimaryApplicant_whenChecked_thenPrimaryApplicantDataNOTCleared() {
+        final CaseData caseData = mock(CaseData.class);
+        final CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
+
+        when(featureToggleServiceMock.enableDuplicateExecutorFiltering()).thenReturn(true);
+
+        when(caseData.getCaseType()).thenReturn("");
+        when(caseData.getTitleAndClearingType()).thenReturn("");
+        when(caseData.isPrimaryApplicantApplying()).thenReturn(true);
+
+        solicitorApplicationCompletionTransformer.clearPrimaryApplicantWhenNotInNoneOfTheseTitleAndClearingType(
+                caseDetails);
+
+        verify(caseData, times(0)).clearPrimaryApplicant();
+    }
+
+    // given Case
+    // and CaseType is GrantOfProbate
     // and TitleClearingType is NoneOfThese
     // and PrimaryApplicantApplying is true
     // when transformer clearPrimaryForNoneOfThese called
@@ -286,6 +313,7 @@ class SolicitorApplicationCompletionTransformerTest {
 
         when(featureToggleServiceMock.enableDuplicateExecutorFiltering()).thenReturn(true);
 
+        when(caseData.getCaseType()).thenReturn(CASE_TYPE_GRANT_OF_PROBATE);
         when(caseData.getTitleAndClearingType()).thenReturn(TITLE_AND_CLEARING_NONE_OF_THESE);
         when(caseData.isPrimaryApplicantApplying()).thenReturn(true);
 
@@ -296,6 +324,7 @@ class SolicitorApplicationCompletionTransformerTest {
     }
 
     // given Case
+    // and CaseType is GrantOfProbate
     // and TitleClearingType is not NoneOfThese
     // and PrimaryApplicantApplying is false
     // when transformer clearPrimaryForNoneOfThese called
@@ -308,6 +337,7 @@ class SolicitorApplicationCompletionTransformerTest {
 
         when(featureToggleServiceMock.enableDuplicateExecutorFiltering()).thenReturn(true);
 
+        when(spyCaseData.getCaseType()).thenReturn(CASE_TYPE_GRANT_OF_PROBATE);
         when(spyCaseData.getTitleAndClearingType()).thenReturn("");
         when(spyCaseData.isPrimaryApplicantApplying()).thenReturn(false);
 
@@ -318,6 +348,7 @@ class SolicitorApplicationCompletionTransformerTest {
     }
 
     // given Case
+    // and CaseType is GrantOfProbate
     // and TitleClearingType is not NoneOfThese
     // and PrimaryApplicantApplying is true
     // and enableDuplicateApplicant is false
@@ -330,6 +361,7 @@ class SolicitorApplicationCompletionTransformerTest {
 
         when(featureToggleServiceMock.enableDuplicateExecutorFiltering()).thenReturn(false);
 
+        when(caseData.getCaseType()).thenReturn(CASE_TYPE_GRANT_OF_PROBATE);
         when(caseData.getTitleAndClearingType()).thenReturn("");
         when(caseData.isPrimaryApplicantApplying()).thenReturn(true);
 


### PR DESCRIPTION
This changes the CCD configuration to not retain the values in the associated fields if they are hidden (i.e. when we are no longer in the `None of These` state for the `titleAndClearingType`.

### JIRA link (if applicable) ###
DTSPB-4387

### Change description ###
Change the `RetainHiddenValue` for these fields to `n` which as best I can find documentation should effectively null out these fields. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
