### PR TITLE
DTSPB-4406 Alter markdown filtering to permit 'html-like' entities 

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -30,6 +30,10 @@ public class FeatureToggleService {
         return this.ldClient.boolVariation("probate-newfee-register-code", this.ldUser, true);
     }
 
+    public boolean enableNewMarkdownFiltering() {
+        return this.ldClient.boolVariation("probate-enable-new-markdown-filtering", this.ldUser, false);
+    }
+
     public boolean isFeatureToggleOn(String featureToggleCode, boolean defaultValue) {
         return this.ldClient.boolVariation(featureToggleCode, this.ldUser, defaultValue);
     }

--- a/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
@@ -45,6 +45,9 @@ public class MarkdownValidatorService {
         @Getter
         private boolean invalid = false;
 
+        @Getter
+        private boolean hasHtml = false;
+
         private final String key;
 
         @Override
@@ -121,14 +124,16 @@ public class MarkdownValidatorService {
 
         @Override
         public void visit(HtmlInline htmlInline) {
-            log.trace("{}: reject HtmlInline", key);
-            invalid = true;
+            log.trace("{}: visit HtmlInline", key);
+            hasHtml = true;
+            visitChildren(htmlInline);
         }
 
         @Override
         public void visit(HtmlBlock htmlBlock) {
-            log.trace("{}: reject HtmlBlock", key);
-            invalid = true;
+            log.trace("{}: visit HtmlBlock", key);
+            hasHtml = true;
+            visitChildren(htmlBlock);
         }
 
         @Override

--- a/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/MarkdownValidatorService.java
@@ -43,19 +43,23 @@ public class MarkdownValidatorService {
     @RequiredArgsConstructor
     public static class NontextVisitor extends AbstractVisitor {
         @Getter
-        private boolean invalid = false;
+        private String whyInvalid = null;
 
         @Getter
         private boolean hasHtml = false;
 
         private final String key;
 
+        public boolean isInvalid() {
+            return whyInvalid != null;
+        }
+
         @Override
         public void visitChildren(Node parent) {
             Node node = parent.getFirstChild();
             while (node != null) {
                 // If we have seen any failure we do not need to continue searching the Node tree, so short circuit
-                if (invalid) {
+                if (isInvalid()) {
                     log.trace("{}: has been rejected, short circuit", key);
                     return;
                 }
@@ -71,7 +75,7 @@ public class MarkdownValidatorService {
         @Override
         public void visit(BlockQuote blockQuote) {
             log.trace("{}: reject BlockQuote", key);
-            invalid = true;
+            whyInvalid = "BlockQuote";
         }
 
         @Override
@@ -83,7 +87,7 @@ public class MarkdownValidatorService {
         @Override
         public void visit(Code code) {
             log.trace("{}: reject Code", key);
-            invalid = true;
+            whyInvalid = "Code";
         }
 
         @Override
@@ -95,13 +99,13 @@ public class MarkdownValidatorService {
         @Override
         public void visit(Emphasis emphasis) {
             log.trace("{}: reject Emphasis", key);
-            invalid = true;
+            whyInvalid = "Emphasis";
         }
 
         @Override
         public void visit(FencedCodeBlock fencedCodeBlock) {
             log.trace("{}: reject FencedCodeBlock", key);
-            invalid = true;
+            whyInvalid = "FencedCodeBlock";
         }
 
         @Override
@@ -139,19 +143,19 @@ public class MarkdownValidatorService {
         @Override
         public void visit(Image image) {
             log.trace("{}: reject Image", key);
-            invalid = true;
+            whyInvalid = "Image";
         }
 
         @Override
         public void visit(IndentedCodeBlock indentedCodeBlock) {
             log.trace("{}: reject IndentedCodeBlock", key);
-            invalid = true;
+            whyInvalid = "IndentedCodeBlock";
         }
 
         @Override
         public void visit(Link link) {
             log.trace("{}: reject Link", key);
-            invalid = true;
+            whyInvalid = "Link";
         }
 
         @Override
@@ -181,7 +185,7 @@ public class MarkdownValidatorService {
         @Override
         public void visit(StrongEmphasis strongEmphasis) {
             log.trace("{}: reject StrongEmphasis", key);
-            invalid = true;
+            whyInvalid = "StrongEmphasis";
         }
 
         @Override
@@ -193,19 +197,19 @@ public class MarkdownValidatorService {
         @Override
         public void visit(LinkReferenceDefinition linkReferenceDefinition) {
             log.trace("{}: reject LinkReferenceDefinition", key);
-            invalid = true;
+            whyInvalid = "LinkReferenceDefinition";
         }
 
         @Override
         public void visit(CustomBlock customBlock) {
             log.trace("{}: reject CustomBlock", key);
-            invalid = true;
+            whyInvalid = "CustomBlock";
         }
 
         @Override
         public void visit(CustomNode customNode) {
             log.trace("{}: reject CustomNode", key);
-            invalid = true;
+            whyInvalid = "CustomNode";
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -53,6 +53,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static uk.gov.hmcts.probate.model.Constants.BUSINESS_ERROR;
 import static uk.gov.hmcts.probate.model.Constants.CAVEAT_SOLICITOR_NAME;
@@ -145,7 +146,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -185,7 +186,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -223,7 +224,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -262,7 +263,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -304,7 +305,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -395,7 +396,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Map<String, String> invalidFields = validationResult.invalidFields();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {
@@ -470,7 +471,7 @@ public class NotificationService {
 
         final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        final List<String> invalidFields = validationResult.invalidFields();
+        final Set<String> invalidFields = validationResult.invalidFields().keySet();
         final List<String> htmlFields = validationResult.htmlFields();
 
         if (!invalidFields.isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.probate.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.probate.config.notifications.EmailAddresses;
@@ -38,7 +37,6 @@ import uk.gov.hmcts.probate.service.notification.TemplateService;
 import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
 import uk.gov.hmcts.probate.validator.EmailAddressNotifyValidationRule;
 import uk.gov.hmcts.probate.validator.PersonalisationValidationRule;
-import uk.gov.hmcts.probate.validator.PersonalisationValidationRule.PersonalisationValidationResult;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
 import uk.gov.service.notify.NotificationClient;
@@ -53,7 +51,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static uk.gov.hmcts.probate.model.Constants.BUSINESS_ERROR;
 import static uk.gov.hmcts.probate.model.Constants.CAVEAT_SOLICITOR_NAME;
@@ -74,7 +71,6 @@ public class NotificationService {
     private static final String INVALID_PERSONALISATION_ERROR_MESSAGE =
             "Markdown Link detected in case data, stop sending notification email.";
 
-    @Autowired
     private final EmailAddresses emailAddresses;
     private final NotificationTemplates notificationTemplates;
     private final RegistriesProperties registriesProperties;
@@ -92,8 +88,8 @@ public class NotificationService {
     private final NotificationClientService notificationClientService;
     private final DocumentManagementService documentManagementService;
     private final PersonalisationValidationRule personalisationValidationRule;
-    @Autowired
-    private BusinessValidationMessageService businessValidationMessageService;
+    private final BusinessValidationMessageService businessValidationMessageService;
+
     @Value("${notifications.grantDelayedNotificationPeriodDays}")
     private Long grantDelayedNotificationPeriodDays;
     @Value("${notifications.grantAwaitingDocumentationNotificationPeriodDays}")
@@ -144,19 +140,7 @@ public class NotificationService {
         String emailAddress = getEmail(caseData);
         String reference = caseData.getSolsSolicitorAppReference();
 
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for case: {} fields: {}",
-                    caseDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caseDetails.getId());
 
         log.info("Personlisation complete now get the email repsonse");
         SendEmailResponse response =
@@ -183,20 +167,7 @@ public class NotificationService {
 
         personalisation.replace(PERSONALISATION_APPLICANT_NAME, executor.getName());
 
-
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for case: {} fields: {}",
-                    caseDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caseDetails.getId());
 
         SendEmailResponse response =
             getSendEmailResponse(state, templateId, emailReplyToId, emailAddress, personalisation, reference,
@@ -221,20 +192,7 @@ public class NotificationService {
                         solicitorName, deceasedName);
         String emailReplyToId = registry.getEmailReplyToId();
 
-
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for case: {} fields: {}",
-                    caseDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caseDetails.getId());
 
         log.info("Personlisation complete now get the email response");
 
@@ -261,19 +219,7 @@ public class NotificationService {
         String emailReplyToId = registry.getEmailReplyToId();
         String reference = caveatData.getSolsSolicitorAppReference();
 
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for caveat: {} fields: {}",
-                    caveatDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for caveat: {} fields: {}",
-                    caveatDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caveatDetails.getId());
 
         log.info("Personlisation complete now get the email response");
 
@@ -303,19 +249,7 @@ public class NotificationService {
 
         String reference = caveatDetails.getId().toString();
 
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for caveat: {} fields: {}",
-                    caveatDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for caveat: {} fields: {}",
-                    caveatDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caveatDetails.getId());
 
         SendEmailResponse response = notificationClientService.sendEmail(
                 caveatDetails.getId(), templateId, emailAddress, personalisation, reference);
@@ -394,19 +328,7 @@ public class NotificationService {
                 caseDetails.getData().getLanguagePreference());
         String emailReplyToId = registry.getEmailReplyToId();
 
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Map<String, String> invalidFields = validationResult.invalidFields();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for case: {} fields: {}",
-                    caseDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caseDetails.getId());
 
         SendEmailResponse response =
             getSendEmailResponse(state, templateId, emailReplyToId, executor.getEmail(), personalisation, reference,
@@ -469,19 +391,7 @@ public class NotificationService {
         String emailAddress = caseDetails.getData().getApplicationType().equals(ApplicationType.PERSONAL)
             ? caseDetails.getData().getPrimaryApplicantEmailAddress() : caseDetails.getData().getSolsSolicitorEmail();
 
-        final PersonalisationValidationResult validationResult = personalisationValidationRule
-                .validatePersonalisation(personalisation);
-        final Set<String> invalidFields = validationResult.invalidFields().keySet();
-        final List<String> htmlFields = validationResult.htmlFields();
-
-        if (!invalidFields.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
-        } else if (!htmlFields.isEmpty()) {
-            log.info("Personalisation validation found HTML for case: {} fields: {}",
-                    caseDetails.getId(), validationResult.htmlFields());
-        }
+        doCommonNotificationServiceHandling(personalisation, caseDetails.getId());
 
         SendEmailResponse response = notificationClientService.sendEmail(caseDetails.getId(), templateId, emailAddress,
             personalisation, reference);
@@ -613,5 +523,30 @@ public class NotificationService {
         return caseData.getRemovedRepresentative() != null
                 ? String.join(" ", caseData.getRemovedRepresentative().getSolicitorFirstName(),
                 caseData.getRemovedRepresentative().getSolicitorLastName()) : null;
+    }
+
+    CommonNotificationResult doCommonNotificationServiceHandling(
+            final Map<String, ?> personalisation,
+            final Long caseId) throws NotificationClientException {
+        final PersonalisationValidationRule.PersonalisationValidationResult validationResult =
+                personalisationValidationRule.validatePersonalisation(personalisation);
+        final Map<String, String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
+            log.error("Personalisation validation failed for case: {} fields: {}",
+                    caseId, invalidFields);
+            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseId, validationResult.htmlFields());
+            return CommonNotificationResult.FOUND_HTML;
+        }
+        return CommonNotificationResult.ALL_OK;
+    }
+
+    enum CommonNotificationResult {
+        ALL_OK,
+        FOUND_HTML;
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -38,6 +38,7 @@ import uk.gov.hmcts.probate.service.notification.TemplateService;
 import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
 import uk.gov.hmcts.probate.validator.EmailAddressNotifyValidationRule;
 import uk.gov.hmcts.probate.validator.PersonalisationValidationRule;
+import uk.gov.hmcts.probate.validator.PersonalisationValidationRule.PersonalisationValidationResult;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.probate.model.cases.RegistryLocation;
 import uk.gov.service.notify.NotificationClient;
@@ -142,12 +143,18 @@ public class NotificationService {
         String emailAddress = getEmail(caseData);
         String reference = caseData.getSolsSolicitorAppReference();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidPersonalisation);
+                    caseDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseDetails.getId(), validationResult.htmlFields());
         }
 
         log.info("Personlisation complete now get the email repsonse");
@@ -175,12 +182,19 @@ public class NotificationService {
 
         personalisation.replace(PERSONALISATION_APPLICANT_NAME, executor.getName());
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidPersonalisation);
+                    caseDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseDetails.getId(), validationResult.htmlFields());
         }
 
         SendEmailResponse response =
@@ -206,12 +220,19 @@ public class NotificationService {
                         solicitorName, deceasedName);
         String emailReplyToId = registry.getEmailReplyToId();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidPersonalisation);
+                    caseDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseDetails.getId(), validationResult.htmlFields());
         }
 
         log.info("Personlisation complete now get the email response");
@@ -239,12 +260,18 @@ public class NotificationService {
         String emailReplyToId = registry.getEmailReplyToId();
         String reference = caveatData.getSolsSolicitorAppReference();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for caveat: {} fields: {}",
-                    caveatDetails.getId(), invalidPersonalisation);
+                    caveatDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for caveat: {} fields: {}",
+                    caveatDetails.getId(), validationResult.htmlFields());
         }
 
         log.info("Personlisation complete now get the email response");
@@ -275,12 +302,18 @@ public class NotificationService {
 
         String reference = caveatDetails.getId().toString();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
-            log.error("Personalisation validation failed for case: {} fields: {}",
-                    caveatDetails.getId(), invalidPersonalisation);
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
+            log.error("Personalisation validation failed for caveat: {} fields: {}",
+                    caveatDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for caveat: {} fields: {}",
+                    caveatDetails.getId(), validationResult.htmlFields());
         }
 
         SendEmailResponse response = notificationClientService.sendEmail(
@@ -360,12 +393,18 @@ public class NotificationService {
                 caseDetails.getData().getLanguagePreference());
         String emailReplyToId = registry.getEmailReplyToId();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidPersonalisation);
+                    caseDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseDetails.getId(), validationResult.htmlFields());
         }
 
         SendEmailResponse response =
@@ -429,12 +468,18 @@ public class NotificationService {
         String emailAddress = caseDetails.getData().getApplicationType().equals(ApplicationType.PERSONAL)
             ? caseDetails.getData().getPrimaryApplicantEmailAddress() : caseDetails.getData().getSolsSolicitorEmail();
 
-        final List<String> invalidPersonalisation = personalisationValidationRule
+        final PersonalisationValidationResult validationResult = personalisationValidationRule
                 .validatePersonalisation(personalisation);
-        if (!invalidPersonalisation.isEmpty()) {
+        final List<String> invalidFields = validationResult.invalidFields();
+        final List<String> htmlFields = validationResult.htmlFields();
+
+        if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
-                    caseDetails.getId(), invalidPersonalisation);
+                    caseDetails.getId(), invalidFields);
             throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+        } else if (!htmlFields.isEmpty()) {
+            log.info("Personalisation validation found HTML for case: {} fields: {}",
+                    caseDetails.getId(), validationResult.htmlFields());
         }
 
         SendEmailResponse response = notificationClientService.sendEmail(caseDetails.getId(), templateId, emailAddress,

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public class PersonalisationValidationRule {
     private final MarkdownValidatorService markdownValidatorService;
 
     public <T> PersonalisationValidationResult validatePersonalisation(final Map<String, T> personalisation) {
-        final List<String> invalidFields = new ArrayList<>();
+        final Map<String, String> invalidFields = new HashMap<>();
         final List<String> htmlFields = new ArrayList<>();
         for (final var entry : personalisation.entrySet()) {
             if (entry.getValue() != null) {
@@ -31,7 +32,7 @@ public class PersonalisationValidationRule {
                 MarkdownValidatorService.NontextVisitor nontextVisit = markdownValidatorService.getNontextVisitor(key);
                 parsed.accept(nontextVisit);
                 if (nontextVisit.isInvalid()) {
-                    invalidFields.add(key);
+                    invalidFields.put(key, nontextVisit.getWhyInvalid());
                 }
                 if (nontextVisit.isHasHtml()) {
                     htmlFields.add(key);
@@ -39,11 +40,13 @@ public class PersonalisationValidationRule {
             }
         }
 
-        return new PersonalisationValidationResult(invalidFields, htmlFields);
+        return new PersonalisationValidationResult(
+                Collections.unmodifiableMap(invalidFields),
+                Collections.unmodifiableList(htmlFields));
     }
 
     public record PersonalisationValidationResult(
-        List<String> invalidFields,
+        Map<String, String> invalidFields,
         List<String> htmlFields) {
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
@@ -12,32 +13,44 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class PersonalisationValidationRule {
-
     private final Parser markdownParser;
 
     private final MarkdownValidatorService markdownValidatorService;
 
+    private final FeatureToggleService featureToggleService;
+
+    private final Pattern markdownLinkPattern =
+            Pattern.compile("^\\[(.*?)]\\((https?:\\/\\/.*?)\\)$", Pattern.CASE_INSENSITIVE);
+
     public PersonalisationValidationResult validatePersonalisation(final Map<String, ?> personalisation) {
+        final boolean enableMarkdownFiltering = featureToggleService.enableNewMarkdownFiltering();
+
         final Map<String, String> invalidFields = new HashMap<>();
         final List<String> htmlFields = new ArrayList<>();
         for (final var entry : personalisation.entrySet()) {
             if (entry.getValue() != null) {
-                final String key = entry.getKey();
-                final String entryValue = entry.getValue().toString();
-                final Node parsed = markdownParser.parse(entryValue);
+                if (enableMarkdownFiltering) {
+                    final String key = entry.getKey();
+                    final String entryValue = entry.getValue().toString();
+                    final Node parsed = markdownParser.parse(entryValue);
 
-                MarkdownValidatorService.NontextVisitor nontextVisit = markdownValidatorService.getNontextVisitor(key);
-                parsed.accept(nontextVisit);
-                if (nontextVisit.isInvalid()) {
-                    invalidFields.put(key, nontextVisit.getWhyInvalid());
-                }
-                if (nontextVisit.isHasHtml()) {
-                    htmlFields.add(key);
+                    MarkdownValidatorService.NontextVisitor nontextVisit = markdownValidatorService
+                            .getNontextVisitor(key);
+                    parsed.accept(nontextVisit);
+                    if (nontextVisit.isInvalid()) {
+                        invalidFields.put(key, nontextVisit.getWhyInvalid());
+                    }
+                    if (nontextVisit.isHasHtml()) {
+                        htmlFields.add(key);
+                    }
+                } else {
+                    doOldMarkdownFiltering(entry, invalidFields);
                 }
             }
         }
@@ -45,6 +58,19 @@ public class PersonalisationValidationRule {
         return new PersonalisationValidationResult(
                 Collections.unmodifiableMap(invalidFields),
                 Collections.unmodifiableList(htmlFields));
+    }
+
+    void doOldMarkdownFiltering(Map.Entry<String, ?> entry, Map<String, String> invalidFields) {
+        log.debug("Using old markdown filtering");
+        String entryValue = entry.getValue().toString();
+        int firstIndex = entryValue.indexOf('[');
+        int secondIndex = entryValue.indexOf(')');
+        if (firstIndex != -1 && secondIndex != -1 && firstIndex < secondIndex) {
+            String valueToValidate = entryValue.substring(firstIndex, secondIndex + 1);
+            if (!valueToValidate.isEmpty() && markdownLinkPattern.matcher(valueToValidate).find()) {
+                invalidFields.put(entry.getKey(), "OLD_LINK");
+            }
+        }
     }
 
     public record PersonalisationValidationResult(

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.probate.validator;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.springframework.stereotype.Component;
@@ -14,13 +15,14 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PersonalisationValidationRule {
 
     private final Parser markdownParser;
 
     private final MarkdownValidatorService markdownValidatorService;
 
-    public <T> PersonalisationValidationResult validatePersonalisation(final Map<String, T> personalisation) {
+    public PersonalisationValidationResult validatePersonalisation(final Map<String, ?> personalisation) {
         final Map<String, String> invalidFields = new HashMap<>();
         final List<String> htmlFields = new ArrayList<>();
         for (final var entry : personalisation.entrySet()) {

--- a/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
+++ b/src/main/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRule.java
@@ -19,8 +19,9 @@ public class PersonalisationValidationRule {
 
     private final MarkdownValidatorService markdownValidatorService;
 
-    public <T> List<String> validatePersonalisation(final Map<String, T> personalisation) {
+    public <T> PersonalisationValidationResult validatePersonalisation(final Map<String, T> personalisation) {
         final List<String> invalidFields = new ArrayList<>();
+        final List<String> htmlFields = new ArrayList<>();
         for (final var entry : personalisation.entrySet()) {
             if (entry.getValue() != null) {
                 final String key = entry.getKey();
@@ -32,8 +33,17 @@ public class PersonalisationValidationRule {
                 if (nontextVisit.isInvalid()) {
                     invalidFields.add(key);
                 }
+                if (nontextVisit.isHasHtml()) {
+                    htmlFields.add(key);
+                }
             }
         }
-        return Collections.unmodifiableList(invalidFields);
+
+        return new PersonalisationValidationResult(invalidFields, htmlFields);
+    }
+
+    public record PersonalisationValidationResult(
+        List<String> invalidFields,
+        List<String> htmlFields) {
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/MarkdownValidatorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/MarkdownValidatorServiceTest.java
@@ -32,6 +32,7 @@ import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.probate.service.MarkdownValidatorService.NontextVisitor;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -207,7 +208,9 @@ class MarkdownValidatorServiceTest {
 
         visitor.visit(node);
 
-        assertTrue(visitor.isInvalid(), "After visiting HtmlInline should be invalid");
+        assertAll(
+                () -> assertFalse(visitor.isInvalid(), "After visiting HtmlInline should be valid"),
+                () -> assertTrue(visitor.isHasHtml(), "After visiting HtmlInline should haveHtml"));
     }
 
     @Test
@@ -217,7 +220,9 @@ class MarkdownValidatorServiceTest {
 
         visitor.visit(node);
 
-        assertTrue(visitor.isInvalid(), "After visiting HtmlBlock should be invalid");
+        assertAll(
+                () -> assertFalse(visitor.isInvalid(), "After visiting HtmlBlock should be valid"),
+                () -> assertTrue(visitor.isHasHtml(), "After visiting HtmlBlock should haveHtml"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
@@ -1,0 +1,138 @@
+package uk.gov.hmcts.probate.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.probate.config.notifications.EmailAddresses;
+import uk.gov.hmcts.probate.config.notifications.NotificationTemplates;
+import uk.gov.hmcts.probate.config.properties.registries.RegistriesProperties;
+import uk.gov.hmcts.probate.service.documentmanagement.DocumentManagementService;
+import uk.gov.hmcts.probate.service.notification.CaveatPersonalisationService;
+import uk.gov.hmcts.probate.service.notification.GrantOfRepresentationPersonalisationService;
+import uk.gov.hmcts.probate.service.notification.SentEmailPersonalisationService;
+import uk.gov.hmcts.probate.service.notification.SmeeAndFordPersonalisationService;
+import uk.gov.hmcts.probate.service.notification.TemplateService;
+import uk.gov.hmcts.probate.service.template.pdf.PDFManagementService;
+import uk.gov.hmcts.probate.service.NotificationService.CommonNotificationResult;
+import uk.gov.hmcts.probate.validator.EmailAddressNotifyValidationRule;
+import uk.gov.hmcts.probate.validator.PersonalisationValidationRule;
+import uk.gov.hmcts.probate.validator.PersonalisationValidationRule.PersonalisationValidationResult;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class NotificationServiceTest {
+
+    @Mock
+    private EmailAddresses emailAddressesMock;
+    @Mock
+    private NotificationTemplates notificationTemplatesMock;
+    @Mock
+    private RegistriesProperties registriesPropertiesMock;
+    @Mock
+    private NotificationClient notificationClientMock;
+    @Mock
+    private MarkdownTransformationService markdownTransformationServiceMock;
+    @Mock
+    private PDFManagementService pdfManagementServiceMock;
+    @Mock
+    private EventValidationService eventValidationServiceMock;
+    @Mock
+    private List<EmailAddressNotifyValidationRule> emailAddressNotifyValidationRulesMock;
+    @Mock
+    private GrantOfRepresentationPersonalisationService grantOfRepresentationPersonalisationServiceMock;
+    @Mock
+    private SmeeAndFordPersonalisationService smeeAndFordPersonalisationServiceMock;
+    @Mock
+    private CaveatPersonalisationService caveatPersonalisationServiceMock;
+    @Mock
+    private SentEmailPersonalisationService sentEmailPersonalisationServiceMock;
+    @Mock
+    private TemplateService templateServiceMock;
+    @Mock
+    private AuthTokenGenerator serviceAuthTokenGeneratorMock;
+    @Mock
+    private NotificationClientService notificationClientServiceMock;
+    @Mock
+    private DocumentManagementService documentManagementServiceMock;
+    @Mock
+    private PersonalisationValidationRule personalisationValidationRuleMock;
+    @Mock
+    private BusinessValidationMessageService businessValidationMessageService;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+    
+    @Test
+    void givenPersonalisationWithMarkdown_whenCommonValidation_thenThrows() {
+        final Map<String, ?> dummyPersonalisation = Collections.emptyMap();
+        final Long dummyCaseId = 1L;
+
+        final PersonalisationValidationResult mockResult = new PersonalisationValidationResult(
+                Map.of("fieldName", "Identified"),
+                List.of());
+
+        when(personalisationValidationRuleMock.validatePersonalisation(dummyPersonalisation))
+                .thenReturn(mockResult);
+
+        assertThrows(NotificationClientException.class, () ->
+                notificationService.doCommonNotificationServiceHandling(dummyPersonalisation, dummyCaseId));
+    }
+
+    @Test
+    void givenPersonalisationWithHtml_whenCommonValidation_thenReturnsHtmlFound() throws NotificationClientException {
+        final Map<String, ?> dummyPersonalisation = Collections.emptyMap();
+        final Long dummyCaseId = 1L;
+
+        final PersonalisationValidationResult mockResult = new PersonalisationValidationResult(
+                Map.of(),
+                List.of("fieldName"));
+
+        when(personalisationValidationRuleMock.validatePersonalisation(dummyPersonalisation))
+                .thenReturn(mockResult);
+
+        final var result = notificationService.doCommonNotificationServiceHandling(dummyPersonalisation, dummyCaseId);
+
+        assertEquals(CommonNotificationResult.FOUND_HTML, result);
+    }
+
+    @Test
+    void givenPersonalisationWithNoIssue_whenCommonValidation_thenReturnsAllOk() throws NotificationClientException {
+        final Map<String, ?> dummyPersonalisation = Collections.emptyMap();
+        final Long dummyCaseId = 1L;
+
+        final PersonalisationValidationResult mockResult = new PersonalisationValidationResult(
+                Map.of(),
+                List.of());
+
+        when(personalisationValidationRuleMock.validatePersonalisation(dummyPersonalisation))
+                .thenReturn(mockResult);
+
+        final var result = notificationService.doCommonNotificationServiceHandling(dummyPersonalisation, dummyCaseId);
+
+        assertEquals(CommonNotificationResult.ALL_OK, result);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.MarkdownValidatorService;
 
 import java.util.ArrayList;
@@ -36,6 +38,9 @@ class PersonalisationValidationRuleTest {
 
     @Spy
     MarkdownValidatorService markdownValidatorService;
+
+    @Mock
+    FeatureToggleService featureToggleService;
 
     @InjectMocks
     private PersonalisationValidationRule personalisationValidationRule;
@@ -69,6 +74,8 @@ class PersonalisationValidationRuleTest {
         personalisation.put("numlist_alt", "1) list");
         personalisation.put("hrule", "---");
         personalisation.put("hrule_alt", "***");
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
 
         final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
                 .invalidFields()
@@ -116,6 +123,8 @@ class PersonalisationValidationRuleTest {
         personalisation.put("single_image", "Some text ![example](http://example.com/img.png)");
         personalisation.put("image_with_ref", "Some text ![link][1]\n\nMore text\n\n[1]: http://example.com/img.png");
 
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
+
         final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
                 .invalidFields()
                 .keySet();
@@ -134,9 +143,86 @@ class PersonalisationValidationRuleTest {
     }
 
     @Test
+    void givenNonpermittedMarkdownInputsAndNewHandlingDisabled_whenValidated_thenReturnsFewerInvalid() {
+        final Map<String, Object> personalisation = new HashMap<>();
+
+        // Link handling
+        personalisation.put("single_link", "Some text [example](http://example.com)");
+        personalisation.put("bypass_with_early_rsqb", "[example\\]](http://example.com)");
+
+        // Images (not mentioned in Notify documentation, but seems like we shouldn't be permitting this
+        personalisation.put("single_image", "Some text ![example](http://example.com/img.png)");
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(false);
+
+        final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
+
+        final Function<String, Executable> assertContains = name -> {
+            return () -> assertTrue(result.contains(name), "result did not contain " + name);
+        };
+
+        final List<Executable> assertions = new ArrayList<Executable>();
+        assertions.add(() -> assertEquals(personalisation.size(), result.size(), "Did not identify all issues"));
+        for (String key : personalisation.keySet()) {
+            assertions.add(assertContains.apply(key));
+        }
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void givenNonpermittedMarkdownInputsAndNewHandlingDisabled_whenValidated_thenReturnsMoreValid() {
+        final Map<String, Object> personalisation = new HashMap<>();
+
+        // Documented as unsupported by Notify
+        personalisation.put("with_bold", "bold **text**");
+        personalisation.put("with_ital", "ital *text*");
+        personalisation.put("with_bold_alt", "bold __text__");
+        personalisation.put("with_ital_alt", "ital _text_");
+        personalisation.put("inline_code", "`inline code`");
+        personalisation.put("code_block", "```\ncode\nblock\n```");
+        personalisation.put("code_block_alt", "    code\n    block");
+
+        // Not explicitly documented as supported or unsupported (the documentation refers to "inset text"
+        // but uses: " ^ inset text" as the example. Unclear if this is just a nonstandard alternative, but
+        // a stock markdown implementation will not catch it. This is likely because `>` would be removed
+        // by any html filtering.
+        personalisation.put("block_quote", "> block_quote");
+
+        // Link handling
+        personalisation.put("bypass_using_match_before", "[) [example](http://example.com)");
+        personalisation.put("link_with_ref", "Some text [link][1]\n\nMore text\n\n[1]: http://example.com");
+
+        // Images (not mentioned in Notify documentation, but seems like we shouldn't be permitting this
+        personalisation.put("image_with_ref", "Some text ![link][1]\n\nMore text\n\n[1]: http://example.com/img.png");
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(false);
+
+        final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
+
+        final Function<String, Executable> assertContains = name -> {
+            return () -> assertFalse(result.contains(name), "result should not contain " + name);
+        };
+
+        final List<Executable> assertions = new ArrayList<Executable>();
+        assertions.add(() -> assertEquals(0, result.size(), "Old handling unexpectly identified issues"));
+        for (String key : personalisation.keySet()) {
+            assertions.add(assertContains.apply(key));
+        }
+
+        assertAll(assertions);
+    }
+
+    @Test
     void givenInput_whenValidatorFlags_thenRejected() {
         final var key = "key";
         final var personalisation = Map.ofEntries(Map.entry(key, "value"));
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
 
         final var visitorMock = mock(MarkdownValidatorService.NontextVisitor.class);
         when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
@@ -159,6 +245,8 @@ class PersonalisationValidationRuleTest {
     void givenInput_whenValidatorPasses_thenAccepted() {
         final var key = "key";
         final var personalisation = Map.ofEntries(Map.entry(key, "value"));
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
 
         final var visitorMock = mock(MarkdownValidatorService.NontextVisitor.class);
         when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
@@ -188,6 +276,7 @@ class PersonalisationValidationRuleTest {
         final var visitorSpy = spy(markdownValidatorService.getNontextVisitor("key"));
 
         when(markdownValidatorService.getNontextVisitor(any())).thenReturn(visitorSpy);
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
 
         personalisationValidationRule.validatePersonalisation(personalisation);
 
@@ -211,6 +300,8 @@ class PersonalisationValidationRuleTest {
     void shouldRetunEmptyListForNullValid() {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("field1", null);
+
+        when(featureToggleService.enableNewMarkdownFiltering()).thenReturn(true);
 
         Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
                 .invalidFields()

--- a/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
@@ -69,7 +69,8 @@ class PersonalisationValidationRuleTest {
         personalisation.put("hrule", "---");
         personalisation.put("hrule_alt", "***");
 
-        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
+        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields();
 
         final Function<String, Executable> assertNotContains = name -> {
             return () -> assertFalse(result.contains(name), "result should not contain " + name);
@@ -113,7 +114,8 @@ class PersonalisationValidationRuleTest {
         personalisation.put("single_image", "Some text ![example](http://example.com/img.png)");
         personalisation.put("image_with_ref", "Some text ![link][1]\n\nMore text\n\n[1]: http://example.com/img.png");
 
-        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
+        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields();
 
         final Function<String, Executable> assertContains = name -> {
             return () -> assertTrue(result.contains(name), "result did not contain " + name);
@@ -137,7 +139,7 @@ class PersonalisationValidationRuleTest {
         when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
         when(visitorMock.isInvalid()).thenReturn(true);
 
-        final var result = personalisationValidationRule.validatePersonalisation(personalisation);
+        final var result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
 
         final List<Executable> assertions = List.of(
                 () -> verify(markdownValidatorService).getNontextVisitor(any()),
@@ -157,7 +159,7 @@ class PersonalisationValidationRuleTest {
         when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
         when(visitorMock.isInvalid()).thenReturn(false);
 
-        final var result = personalisationValidationRule.validatePersonalisation(personalisation);
+        final var result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
 
         final List<Executable> assertions = List.of(
                 () -> verify(markdownValidatorService).getNontextVisitor(any()),
@@ -193,7 +195,7 @@ class PersonalisationValidationRuleTest {
         personalisation.put("field1", "Some text");
         personalisation.put("field2", "Another  text");
 
-        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
+        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
 
         assertTrue(result.isEmpty());
     }
@@ -203,7 +205,7 @@ class PersonalisationValidationRuleTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("field1", null);
 
-        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation);
+        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
 
         assertTrue(result.isEmpty());
     }

--- a/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/validator/PersonalisationValidationRuleTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -69,8 +70,9 @@ class PersonalisationValidationRuleTest {
         personalisation.put("hrule", "---");
         personalisation.put("hrule_alt", "***");
 
-        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
-                .invalidFields();
+        final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
 
         final Function<String, Executable> assertNotContains = name -> {
             return () -> assertFalse(result.contains(name), "result should not contain " + name);
@@ -114,8 +116,9 @@ class PersonalisationValidationRuleTest {
         personalisation.put("single_image", "Some text ![example](http://example.com/img.png)");
         personalisation.put("image_with_ref", "Some text ![link][1]\n\nMore text\n\n[1]: http://example.com/img.png");
 
-        final List<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
-                .invalidFields();
+        final Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
 
         final Function<String, Executable> assertContains = name -> {
             return () -> assertTrue(result.contains(name), "result did not contain " + name);
@@ -139,7 +142,9 @@ class PersonalisationValidationRuleTest {
         when(markdownValidatorService.getNontextVisitor(key)).thenReturn(visitorMock);
         when(visitorMock.isInvalid()).thenReturn(true);
 
-        final var result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
+        final var result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
 
         final List<Executable> assertions = List.of(
                 () -> verify(markdownValidatorService).getNontextVisitor(any()),
@@ -195,7 +200,9 @@ class PersonalisationValidationRuleTest {
         personalisation.put("field1", "Some text");
         personalisation.put("field2", "Another  text");
 
-        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
+        Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
 
         assertTrue(result.isEmpty());
     }
@@ -205,7 +212,9 @@ class PersonalisationValidationRuleTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("field1", null);
 
-        List<String> result = personalisationValidationRule.validatePersonalisation(personalisation).invalidFields();
+        Set<String> result = personalisationValidationRule.validatePersonalisation(personalisation)
+                .invalidFields()
+                .keySet();
 
         assertTrue(result.isEmpty());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPB-4406

### Change description ###
Alters the behaviour when encountering HTML to permit but log. Also adds reasons for why a field has failed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
