### PR TITLE
DTSBP-4387 Clear primaryApplicant fields when changing from None of These to another titleAndClearingType

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/model/Constants.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/Constants.java
@@ -35,7 +35,7 @@ public final class Constants {
     public static final String DOC_TYPE_CHERISHED = "cherished";
     public static final String DOC_TYPE_OTHER = "other";
     public static final String DATE_OF_DEATH_TYPE_DEFAULT = "diedOn";
-    public static final String CASE_TYPE_DEFAULT = "gop";
+    public static final String CASE_TYPE_GRANT_OF_PROBATE = "gop";
     public static final String DOCMOSIS_OUTPUT_PDF = "pdf";
     public static final String DOCMOSIS_OUTPUT_HTML = "html";
     public static final String REDEC_NOTIFICATION_SENT_STATE = "BORedecNotificationSent";
@@ -74,6 +74,7 @@ public final class Constants {
     public static final String TITLE_AND_CLEARING_PARTNER_OTHERS_RENOUNCING = "TCTPartOthersRenouncing";
     public static final String TITLE_AND_CLEARING_PARTNER_SUCC_ALL_RENOUNCING = "TCTPartSuccAllRenouncing";
     public static final String TITLE_AND_CLEARING_PARTNER_ALL_RENOUNCING = "TCTPartAllRenouncing";
+    public static final String TITLE_AND_CLEARING_NONE_OF_THESE = "TCTNoT";
     public static final String REASON_FOR_NOT_APPLYING_RENUNCIATION = "Renunciation";
     public static final String REASON_FOR_NOT_APPLYING_MENTALLY_INCAPABLE = "MentallyIncapable";
     public static final String REASON_FOR_NOT_APPLYING_DIED_BEFORE = "DiedBefore";

--- a/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/ccd/raw/request/CaseData.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.probate.controller.validation.AmendCaseDetailsGroup;
 import uk.gov.hmcts.probate.controller.validation.ApplicationAdmonGroup;
 import uk.gov.hmcts.probate.controller.validation.ApplicationCreatedGroup;
@@ -68,12 +69,14 @@ import java.util.List;
 
 import static uk.gov.hmcts.probate.model.Constants.NO;
 import static uk.gov.hmcts.probate.model.Constants.YES;
+import static uk.gov.hmcts.probate.transformer.CallbackResponseTransformer.ANSWER_NO;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @SuperBuilder
 @Jacksonized
 @EqualsAndHashCode(callSuper = true)
 @Data
+@Slf4j
 public class CaseData extends CaseDataParent {
 
     // Tasklist update
@@ -706,6 +709,30 @@ public class CaseData extends CaseDataParent {
 
     public boolean isLanguagePreferenceWelsh() {
         return YES.equals(getLanguagePreferenceWelsh());
+    }
+
+    public void clearPrimaryApplicant() {
+        log.debug("Clearing primary applicant information from CaseData");
+
+
+        this.setPrimaryApplicantIsApplying(null);
+
+        this.setPrimaryApplicantForenames(null);
+        this.setPrimaryApplicantSurname(null);
+
+        // This is to be consistent with the behaviour currently exhibited by the service when creating
+        // a case with a non-NoneOfThese TitleAndClearingType.
+        this.setPrimaryApplicantHasAlias(ANSWER_NO);
+        this.setPrimaryApplicantAlias(null);
+
+
+        // As above this is to be consistent with the behaviour currently exhibited by the service when
+        // creating a case with a non-NoneOfThese TitleAndClearingType.
+        final SolsAddress nullAddress = SolsAddress.builder().build();
+        this.setPrimaryApplicantAddress(nullAddress);
+
+        this.setPrimaryApplicantEmailAddress(null);
+        this.setPrimaryApplicantPhoneNumber(null);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.probate.service;
 
-import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.LDClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,32 +10,43 @@ import org.springframework.stereotype.Service;
 public class FeatureToggleService {
 
     private final LDClient ldClient;
-    private final LDUser ldUser;
-    private final LDUser.Builder ldUserBuilder;
+    private final LDContext ldContext;
+
 
     @Autowired
     public FeatureToggleService(LDClient ldClient, @Value("${ld.user.key}") String ldUserKey,
                                 @Value("${ld.user.firstName}") String ldUserFirstName,
                                 @Value("${ld.user.lastName}") String ldUserLastName) {
+
+        final String contextName = new StringBuilder()
+                .append(ldUserFirstName)
+                .append(" ")
+                .append(ldUserLastName)
+                .toString();
+
         this.ldClient = ldClient;
-       
-        this.ldUserBuilder = new LDUser.Builder(ldUserKey)
-            .firstName(ldUserFirstName)
-            .lastName(ldUserLastName)
-            .custom("timestamp", String.valueOf(System.currentTimeMillis()));
-        this.ldUser = this.ldUserBuilder.build();
+        this.ldContext = LDContext.builder(ldUserKey)
+                .name(contextName)
+                .kind("application")
+                .set("timestamp", String.valueOf(System.currentTimeMillis()))
+                .build();
+
     }
 
     public boolean isNewFeeRegisterCodeEnabled() {
-        return this.ldClient.boolVariation("probate-newfee-register-code", this.ldUser, true);
+        return isFeatureToggleOn("probate-newfee-register-code", true);
     }
 
     public boolean enableNewMarkdownFiltering() {
-        return this.ldClient.boolVariation("probate-enable-new-markdown-filtering", this.ldUser, false);
+        return isFeatureToggleOn("probate-enable-new-markdown-filtering", false);
+    }
+
+    public boolean enableDuplicateExecutorFiltering() {
+        return isFeatureToggleOn("probate-enable-duplicate-executor-filtering", false);
     }
 
     public boolean isFeatureToggleOn(String featureToggleCode, boolean defaultValue) {
-        return this.ldClient.boolVariation(featureToggleCode, this.ldUser, defaultValue);
+        return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
     }
 
     public boolean enableNewAliasTransformation() {

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CaseDataTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CaseDataTransformer.java
@@ -56,7 +56,12 @@ public class CaseDataTransformer {
 
 
     public void transformCaseDataForValidateProbate(CallbackRequest callbackRequest) {
-        final var caseData = callbackRequest.getCaseDetails().getData();
+        final var caseDetails = callbackRequest.getCaseDetails();
+        final var caseData = caseDetails.getData();
+
+        solicitorApplicationCompletionTransformer.clearPrimaryApplicantWhenNotInNoneOfTheseTitleAndClearingType(
+                caseDetails);
+
         resetCaseDataTransformer.resetExecutorLists(caseData);
         solicitorApplicationCompletionTransformer.setFieldsIfSolicitorIsNotNamedInWillAsAnExecutor(caseData);
         solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
@@ -14,7 +14,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static uk.gov.hmcts.probate.model.ApplicationState.CASE_PRINTED;
+import static uk.gov.hmcts.probate.model.Constants.CASE_TYPE_GRANT_OF_PROBATE;
 import static uk.gov.hmcts.probate.model.Constants.NO;
+import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_NONE_OF_THESE;
 
 @Component
 @Slf4j
@@ -67,6 +69,32 @@ public class SolicitorApplicationCompletionTransformer extends LegalStatementExe
         if (totalAmount.compareTo(BigDecimal.ZERO) == 0) {
             caseDetails.getData().setPaymentTaken(NOT_APPLICABLE);
             caseDetails.setState(CASE_PRINTED.getId());
+        }
+    }
+
+    public void clearPrimaryApplicantWhenNotInNoneOfTheseTitleAndClearingType(CaseDetails caseDetails) {
+        if (featureToggleService.enableDuplicateExecutorFiltering()) {
+            final var caseId = caseDetails.getId();
+            final var caseData = caseDetails.getData();
+
+            final var titleAndClearingType = caseData.getTitleAndClearingType();
+            final var caseType = caseData.getCaseType();
+
+            final var primaryApplicantApplying = caseData.isPrimaryApplicantApplying();
+            final var isNotNoneOfTheseTCT = titleAndClearingType != null
+                    && !TITLE_AND_CLEARING_NONE_OF_THESE.equalsIgnoreCase(titleAndClearingType);
+            final var isGrantOfProbate = CASE_TYPE_GRANT_OF_PROBATE.equalsIgnoreCase(caseType);
+
+            if (isNotNoneOfTheseTCT
+                    && primaryApplicantApplying
+                    && isGrantOfProbate) {
+                log.info("In GrantOfProbate case {} we have primary applicant applying for non-NoneOfThese "
+                        + "TitleAndClearingType {}, clear PrimaryApplicant fields",
+                        caseId,
+                        titleAndClearingType);
+
+                caseData.clearPrimaryApplicant();
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformer.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.service.DateFormatterService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.math.BigDecimal;
@@ -21,11 +22,16 @@ import static uk.gov.hmcts.probate.model.Constants.NO;
 // for caseworker or solicitor journeys
 public class SolicitorApplicationCompletionTransformer extends LegalStatementExecutorTransformer {
 
+    private final FeatureToggleService featureToggleService;
+
     private static final String NOT_APPLICABLE = "NotApplicable";
 
-    public SolicitorApplicationCompletionTransformer(ExecutorListMapperService executorListMapperService,
-                                                     DateFormatterService dateFormatterService) {
+    public SolicitorApplicationCompletionTransformer(
+            final ExecutorListMapperService executorListMapperService,
+            final DateFormatterService dateFormatterService,
+            final FeatureToggleService featureToggleService) {
         super(executorListMapperService, dateFormatterService);
+        this.featureToggleService = featureToggleService;
     }
 
     /**

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="uk.gov.hmcts.probate.service.MarkdownValidatorService" level="INFO" />
+</configuration>

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/ExecutorsTransformerTest.java
@@ -17,17 +17,22 @@ import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.response.ResponseCaseData;
 import uk.gov.hmcts.probate.service.DateFormatterService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_SOLE_PRINCIPLE;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_TRUST_CORP;
@@ -246,22 +251,36 @@ class ExecutorsTransformerTest {
         assertEquals(SOLICITOR_NOT_APPLYING_REASON, cd.getSolsSolicitorNotApplyingReason());
     }
 
+    /* Should this test be in this Test class? It's testing a subclass and is really relying on a third
+     * service (ExecutorListMapperService) to do most of the work here.
+     */
     @Test
     void shouldSwapSolicitorToNotApplyingList() {
-        caseDataBuilder
+        final CaseData caseData = CaseData.builder()
                 .additionalExecutorsApplying(additionalExecutorApplying)
                 .additionalExecutorsNotApplying(additionalExecutorNotApplying)
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
-                .primaryApplicantForenames(EXEC_FIRST_NAME);
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .build();
 
-        final CaseData cd = caseDataBuilder.build();
+        final var executorListMapperSpy = spy(ExecutorListMapperService.class);
 
-        new SolicitorApplicationCompletionTransformer(new ExecutorListMapperService(), new DateFormatterService())
-                .mapSolicitorExecutorFieldsOnCompletion(cd);
+        // We only need these to construct the SolicitorXformer object, we verifyNoInteractions to confirm
+        final var dateFormatterMock = mock(DateFormatterService.class);
+        final var featureToggleMock = mock(FeatureToggleService.class);
 
-        assertEquals(0, cd.getAdditionalExecutorsApplying().size());
-        assertEquals(1, cd.getAdditionalExecutorsNotApplying().size());
+        final var solXformer = new SolicitorApplicationCompletionTransformer(
+                executorListMapperSpy,
+                dateFormatterMock,
+                featureToggleMock);
+        solXformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
+
+        assertAll(
+                () -> assertEquals(0, caseData.getAdditionalExecutorsApplying().size()),
+                () -> assertEquals(1, caseData.getAdditionalExecutorsNotApplying().size()),
+                () -> verifyNoInteractions(dateFormatterMock, featureToggleMock)
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/solicitorexecutors/SolicitorApplicationCompletionTransformerTest.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.probate.transformer.solicitorexecutors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutor;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutorApplying;
 import uk.gov.hmcts.probate.model.ccd.raw.AdditionalExecutorNotApplying;
@@ -17,6 +17,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.CollectionMember;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.service.DateFormatterService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
 
 import java.math.BigDecimal;
@@ -25,8 +26,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.Constants.TITLE_AND_CLEARING_TRUST_CORP;
 import static uk.gov.hmcts.probate.util.CommonVariables.ADDITIONAL_EXECUTOR_APPLYING;
@@ -44,13 +50,7 @@ import static uk.gov.hmcts.probate.util.CommonVariables.SOLS_EXEC_ADDITIONAL_APP
 import static uk.gov.hmcts.probate.util.CommonVariables.SOLS_EXEC_NOT_APPLYING;
 import static uk.gov.hmcts.probate.util.CommonVariables.YES;
 
-@ExtendWith(SpringExtension.class)
 class SolicitorApplicationCompletionTransformerTest {
-
-    private final CaseData.CaseDataBuilder<?, ?> caseDataBuilder = CaseData.builder();
-
-    @Mock
-    private CaseDetails caseDetailsMock;
 
     @Mock
     private DateFormatterService dateFormatterServiceMock;
@@ -58,8 +58,13 @@ class SolicitorApplicationCompletionTransformerTest {
     @Mock
     private ExecutorListMapperService executorListMapperServiceMock;
 
+    @Mock
+    private FeatureToggleService featureToggleServiceMock;
+
     @InjectMocks
-    private SolicitorApplicationCompletionTransformer solicitorApplicationCompletionTransformerMock;
+    private SolicitorApplicationCompletionTransformer solicitorApplicationCompletionTransformer;
+
+    private AutoCloseable closeableMocks;
 
     private List<CollectionMember<AdditionalExecutorApplying>> additionalExecutorApplying;
     private List<CollectionMember<AdditionalExecutorNotApplying>> additionalExecutorNotApplying;
@@ -94,42 +99,57 @@ class SolicitorApplicationCompletionTransformerTest {
 
         dispenseWithNoticeExecList = new ArrayList<>();
         dispenseWithNoticeExecList.add(DISPENSE_WITH_NOTICE_EXEC);
+
+        closeableMocks = MockitoAnnotations.openMocks(this);
     }
 
+    @AfterEach
+    void cleanUp() throws Exception {
+        closeableMocks.close();
+    }
 
+    /* Should this test be in this Test class? It's really relying on the ExecutorListMapperService
+     * to do the work being tested here. (Hence needing to create a new instance with a spy rather
+     * than the common handling with a mock.)
+     */
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo() {
-
-        caseDataBuilder
+        final CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(YES)
                 .titleAndClearingType(TITLE_AND_CLEARING_TRUST_CORP)
                 .anyOtherApplyingPartnersTrustCorp(YES)
                 .additionalExecutorsTrustCorpList(trustCorpsExecutorList)
-                .solsAdditionalExecutorList(solsAdditionalExecutorList);
+                .solsAdditionalExecutorList(solsAdditionalExecutorList)
+                .build();
 
-        CaseData caseData = caseDataBuilder.build();
+        final var executorListMapperSpy = spy(ExecutorListMapperService.class);
 
-        SolicitorApplicationCompletionTransformer solJourneyCompletion =
-            new SolicitorApplicationCompletionTransformer(new ExecutorListMapperService(), new DateFormatterService());
+        final var solApplComplXform = new SolicitorApplicationCompletionTransformer(
+                executorListMapperSpy,
+                dateFormatterServiceMock,
+                featureToggleServiceMock);
 
-        solJourneyCompletion.mapSolicitorExecutorFieldsOnCompletion(caseData);
+        solApplComplXform.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
-        assertEquals(2, caseData.getAdditionalExecutorsApplying().size());
-        assertEquals(3, caseData.getExecutorsApplyingLegalStatement().size());
+        assertAll(
+                () -> assertEquals(2, caseData.getAdditionalExecutorsApplying().size()),
+                () -> assertEquals(3, caseData.getExecutorsApplyingLegalStatement().size()),
+                () -> verifyNoInteractions(dateFormatterServiceMock, featureToggleServiceMock)
+        );
     }
 
     @Test
     void shouldSetLegalStatementFieldsWithNotApplyingExecutorInfo() {
-        caseDataBuilder
+        final CaseDetails caseDetailsMock = mock(CaseDetails.class);
+        final CaseData caseData = CaseData.builder()
                 .solsSolicitorIsExec(YES)
                 .solsSolicitorIsApplying(NO)
                 .additionalExecutorsTrustCorpList(null)
                 .otherPartnersApplyingAsExecutors(null)
                 .dispenseWithNoticeOtherExecsList(dispenseWithNoticeExecList)
-                .solsAdditionalExecutorList(solsAdditionalExecutorList);
-
-        CaseData caseData = caseDataBuilder.build();
+                .solsAdditionalExecutorList(solsAdditionalExecutorList)
+                .build();
 
         when(caseDetailsMock.getData()).thenReturn(caseData);
         when(executorListMapperServiceMock.mapFromDispenseWithNoticeExecsToNotApplyingExecutors(
@@ -137,7 +157,7 @@ class SolicitorApplicationCompletionTransformerTest {
         when(executorListMapperServiceMock.addSolicitorToNotApplyingList(
                 caseDetailsMock.getData(), additionalExecutorNotApplying)).thenReturn(additionalExecutorNotApplying);
 
-        solicitorApplicationCompletionTransformerMock.mapSolicitorExecutorFieldsOnCompletion(caseData);
+        solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
         List<CollectionMember<AdditionalExecutorNotApplying>> legalStatementExecutors = new ArrayList<>();
         legalStatementExecutors.addAll(additionalExecutorNotApplying);
@@ -148,19 +168,19 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantApplying() {
-        caseDataBuilder
-            .primaryApplicantForenames(EXEC_FIRST_NAME)
-            .primaryApplicantSurname(EXEC_SURNAME)
-            .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
-            .primaryApplicantAddress(EXEC_ADDRESS)
-            .primaryApplicantIsApplying(YES);
+        final CaseData caseData = CaseData.builder()
+                .primaryApplicantForenames(EXEC_FIRST_NAME)
+                .primaryApplicantSurname(EXEC_SURNAME)
+                .primaryApplicantAlias(PRIMARY_EXEC_ALIAS_NAMES)
+                .primaryApplicantAddress(EXEC_ADDRESS)
+                .primaryApplicantIsApplying(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(
-                caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
-        solicitorApplicationCompletionTransformerMock.mapSolicitorExecutorFieldsOnCompletion(caseData);
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_APPLYING));
+
+        solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
         assertEquals(additionalExecutorApplying, caseData.getExecutorsApplyingLegalStatement());
         assertEquals(new ArrayList<>(), caseData.getExecutorsNotApplyingLegalStatement());
@@ -168,18 +188,16 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfo_PrimaryApplicantNotApplying() {
-        caseDataBuilder
+        final CaseData caseData = CaseData.builder()
                 .primaryApplicantIsApplying(NO)
                 .solsSolicitorIsApplying(NO)
-                .solsSolicitorIsExec(YES);
+                .solsSolicitorIsExec(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
-                caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
-                    ADDITIONAL_EXECUTOR_NOT_APPLYING));
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
-        solicitorApplicationCompletionTransformerMock.mapSolicitorExecutorFieldsOnCompletion(caseData);
+        solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnCompletion(caseData);
 
         assertEquals(additionalExecutorNotApplying, caseData.getExecutorsNotApplyingLegalStatement());
         assertEquals(new ArrayList<>(), caseData.getExecutorsApplyingLegalStatement());
@@ -187,18 +205,17 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetLegalStatementFieldsWithApplyingExecutorInfoYesNo() {
-        caseDataBuilder
-            .primaryApplicantIsApplying(NO)
-            .solsSolicitorIsApplying(NO)
-            .solsSolicitorIsExec(YES);
+        final CaseData caseData = CaseData.builder()
+                .primaryApplicantIsApplying(NO)
+                .solsSolicitorIsApplying(NO)
+                .solsSolicitorIsExec(YES)
+                .build();
 
-        when(caseDetailsMock.getData()).thenReturn(caseDataBuilder.build());
-        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(
-            caseDetailsMock.getData())).thenReturn(new CollectionMember<>(EXEC_ID,
-            ADDITIONAL_EXECUTOR_NOT_APPLYING));
 
-        CaseData caseData = caseDetailsMock.getData();
-        solicitorApplicationCompletionTransformerMock.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);
+        when(executorListMapperServiceMock.mapFromPrimaryApplicantToNotApplyingExecutor(caseData))
+                .thenReturn(new CollectionMember<>(EXEC_ID, ADDITIONAL_EXECUTOR_NOT_APPLYING));
+
+        solicitorApplicationCompletionTransformer.mapSolicitorExecutorFieldsOnAppDetailsComplete(caseData);
 
         assertEquals(additionalExecutorNotApplying, caseData.getExecutorsNotApplyingLegalStatement());
         assertEquals(new ArrayList<>(), caseData.getExecutorsApplyingLegalStatement());
@@ -211,13 +228,14 @@ class SolicitorApplicationCompletionTransformerTest {
                         .dateCodicilAdded(LocalDate.now().minusDays(1)).build()));
         final List<CollectionMember<String>> formattedDate =
                 Arrays.asList(new CollectionMember<>("Formatted Date"));
-        caseDataBuilder
+
+        final CaseData caseData = CaseData.builder()
                 .willHasCodicils(NO)
                 .codicilAddedDateList(codicilDates)
-                .codicilAddedFormattedDateList(formattedDate);
+                .codicilAddedFormattedDateList(formattedDate)
+                .build();
 
-        CaseData caseData = caseDataBuilder.build();
-        solicitorApplicationCompletionTransformerMock.eraseCodicilAddedDateIfWillHasNoCodicils(caseData);
+        solicitorApplicationCompletionTransformer.eraseCodicilAddedDateIfWillHasNoCodicils(caseData);
 
         assertNull(caseData.getCodicilAddedDateList());
         assertNull(caseData.getCodicilAddedFormattedDateList());
@@ -225,20 +243,20 @@ class SolicitorApplicationCompletionTransformerTest {
 
     @Test
     void shouldSetServiceRequest() {
-        BigDecimal totalAmount = BigDecimal.valueOf(100000);
-        CaseData caseData = caseDataBuilder.build();
-        CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
-        solicitorApplicationCompletionTransformerMock.setFieldsOnServiceRequest(caseDetails, totalAmount);
+        final BigDecimal totalAmount = BigDecimal.valueOf(100000);
+        final CaseData caseData = CaseData.builder().build();
+        final CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
+        solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 
         assertNull(caseData.getPaymentTaken());
     }
 
     @Test
     void shouldSetPaymentTakenNotApplicableWhenNoServiceRequest() {
-        BigDecimal totalAmount = BigDecimal.ZERO;
-        CaseData caseData = caseDataBuilder.build();
-        CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
-        solicitorApplicationCompletionTransformerMock.setFieldsOnServiceRequest(caseDetails, totalAmount);
+        final BigDecimal totalAmount = BigDecimal.ZERO;
+        final CaseData caseData = CaseData.builder().build();
+        final CaseDetails caseDetails = new CaseDetails(caseData, null, 0L);
+        solicitorApplicationCompletionTransformer.setFieldsOnServiceRequest(caseDetails, totalAmount);
 
         assertEquals(NOT_APPLICABLE, caseData.getPaymentTaken());
     }


### PR DESCRIPTION
This changes the behaviour when the `titleAndClearingType` is **not** `TCTNoT` and a `primaryApplicant` is present to set  the `primaryApplicant` fields such that it matches what would be present if the not-`TCTNoT` type had been originally selected.

It also tidies up some of the testing in the related functionality, and remove dependence on deprecated functionality in launchdarkly.

### JIRA link (if applicable) ###
DTSPB-4387

### Change description ###
Adds handling in the callback to reset the associated fields.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
