### PR TITLE
DTSPB-4388 Transform the non-sols alias details once, then drop them

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -38,4 +38,7 @@ public class FeatureToggleService {
         return this.ldClient.boolVariation(featureToggleCode, this.ldUser, defaultValue);
     }
 
+    public boolean enableNewAliasTransformation() {
+        return this.isFeatureToggleOn("probate-enable-new-alias-transformation", false);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -1008,7 +1008,7 @@ public class CallbackResponseTransformer {
         return CallbackResponse.builder().data(responseCaseData).build();
     }
 
-    private ResponseCaseDataBuilder<?, ?> getResponseCaseData(CaseDetails caseDetails, String eventId,
+    ResponseCaseDataBuilder<?, ?> getResponseCaseData(CaseDetails caseDetails, String eventId,
                                                               boolean transform) {
         CaseData caseData = caseDetails.getData();
 
@@ -1309,6 +1309,25 @@ public class CallbackResponseTransformer {
 
 
         return builder;
+    }
+
+    void handleDeceasedAliases(
+            final ResponseCaseDataBuilder<?,?> builder,
+            final CaseData caseData,
+            final Long caseRef) {
+    }
+
+    Set<CollectionMember<AliasName>> convertAliasOnWillToSolsDecAliasList(
+            final Long caseRef,
+            final String otherNameOnWill,
+            final String foreNames,
+            final String lastName) {
+        return Set.of();
+    }
+
+    Set<CollectionMember<AliasName>> convertDecAliasesSolsDecAliasList(
+            final List<CollectionMember<ProbateAliasName>> decAliases) {
+        return Set.of();
     }
 
     OrganisationPolicy buildOrganisationPolicy(CaseDetails caseDetails, String authToken) {

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -1369,7 +1369,12 @@ public class CallbackResponseTransformer {
             newSolsDecAliases.addAll(solsDecAliases);
         }
 
-        builder.solsDeceasedAliasNamesList(newSolsDecAliases.stream().toList());
+
+        Set<String> seenAliasNames = new HashSet<>();
+
+        builder.solsDeceasedAliasNamesList(newSolsDecAliases.stream()
+                .filter(a -> seenAliasNames.add(a.getValue().getSolsAliasname()))
+                .toList());
     }
 
     Set<CollectionMember<AliasName>> convertAliasOnWillToSolsDecAliasList(

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -1047,7 +1047,6 @@ public class CallbackResponseTransformer {
             .primaryApplicantAddress(caseData.getPrimaryApplicantAddress())
             .primaryApplicantNotRequiredToSendDocuments(caseData.getPrimaryApplicantNotRequiredToSendDocuments())
             .solsAdditionalInfo(caseData.getSolsAdditionalInfo())
-            .solsDeceasedAliasNamesList(getSolsDeceasedAliasNamesList(caseData))
             .caseMatches(caseData.getCaseMatches())
 
             .solsSOTNeedToUpdate(caseData.getSolsSOTNeedToUpdate())
@@ -1284,9 +1283,6 @@ public class CallbackResponseTransformer {
             .paymentTaken(caseData.getPaymentTaken())
             .hmrcLetterId(caseData.getHmrcLetterId())
             .uniqueProbateCodeId(caseData.getUniqueProbateCodeId())
-            .deceasedAnyOtherNameOnWill(caseData.getDeceasedAnyOtherNameOnWill())
-            .deceasedAliasFirstNameOnWill(caseData.getDeceasedAliasFirstNameOnWill())
-            .deceasedAliasLastNameOnWill(caseData.getDeceasedAliasLastNameOnWill())
             .boHandoffReasonList(getHandoffReasonList(caseData))
             .lastModifiedDateForDormant(getLastModifiedDate(eventId, caseData.getLastModifiedDateForDormant()))
             .applicationSubmittedBy(caseData.getApplicationSubmittedBy())
@@ -1299,6 +1295,11 @@ public class CallbackResponseTransformer {
             .citizenResponses(caseData.getCitizenResponses())
             .citizenDocumentsUploaded(caseData.getCitizenDocumentsUploaded())
             .isSaveAndClose(caseData.getIsSaveAndClose());
+
+        handleDeceasedAliases(
+                builder,
+                caseData,
+                caseDetails.getId());
 
         if (transform) {
             updateCaseBuilderForTransformCase(caseData, builder);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -4787,6 +4787,86 @@ class CallbackResponseTransformerTest {
     }
 
     @Test
+    void verify_getResponseCaseData_no_willAlias_decAlias_solDecAlias() {
+        final var builder = ResponseCaseData.builder();
+        final var builderSpy = spy(builder);
+
+        final CaseData caseData = CaseData.builder()
+                .deceasedAnyOtherNameOnWill(NO)
+                .deceasedAliasFirstNameOnWill(WILL_ALIAS_FN)
+                .deceasedAliasLastNameOnWill(WILL_ALIAS_LN)
+                .deceasedAliasNameList(List.of(DEC_PROBATE_ALIAS_NAME_CM))
+                .solsDeceasedAliasNamesList(List.of(SOL_DEC_ALIAS_NAME_CM))
+                .build();
+
+        when(caseDetailsMock.getData()).thenReturn(caseData);
+
+        final String eventId = "TEST_EVENT";
+        final boolean transform = false;
+
+        final Set<CollectionMember<AliasName>> expAliases = Set.of(
+                WILL_ALIAS_NAME_CM,
+                DEC_ALIAS_NAME_CM,
+                SOL_DEC_ALIAS_NAME_CM);
+        final AliasMatcher expAliasMatcher = new AliasMatcher(expAliases);
+
+        try (MockedStatic<ResponseCaseData> respCaseData = mockStatic(ResponseCaseData.class)) {
+            respCaseData.when(ResponseCaseData::builder).thenReturn(builderSpy);
+
+            underTest.getResponseCaseData(caseDetailsMock, eventId, transform);
+        }
+
+        verify(builderSpy).deceasedAnyOtherNameOnWill(NO);
+        verify(builderSpy).deceasedAliasFirstNameOnWill(WILL_ALIAS_FN);
+        verify(builderSpy).deceasedAliasLastNameOnWill(WILL_ALIAS_LN);
+
+        verify(builderSpy, never()).deceasedAliasNamesList(any());
+
+        verify(builderSpy, never()).solsDeceasedAliasNamesList(argThat(expAliasMatcher.invert()));
+        verify(builderSpy).solsDeceasedAliasNamesList(argThat(expAliasMatcher));
+    }
+
+    @Test
+    void verify_getResponseCaseData_yes_willAlias_decAlias_solDecAlias() {
+        final var builder = ResponseCaseData.builder();
+        final var builderSpy = spy(builder);
+
+        final CaseData caseData = CaseData.builder()
+                .deceasedAnyOtherNameOnWill(YES)
+                .deceasedAliasFirstNameOnWill(WILL_ALIAS_FN)
+                .deceasedAliasLastNameOnWill(WILL_ALIAS_LN)
+                .deceasedAliasNameList(List.of(DEC_PROBATE_ALIAS_NAME_CM))
+                .solsDeceasedAliasNamesList(List.of(SOL_DEC_ALIAS_NAME_CM))
+                .build();
+
+        when(caseDetailsMock.getData()).thenReturn(caseData);
+
+        final String eventId = "TEST_EVENT";
+        final boolean transform = false;
+
+        final Set<CollectionMember<AliasName>> expAliases = Set.of(
+                WILL_ALIAS_NAME_CM,
+                DEC_ALIAS_NAME_CM,
+                SOL_DEC_ALIAS_NAME_CM);
+        final AliasMatcher expAliasMatcher = new AliasMatcher(expAliases);
+
+        try (MockedStatic<ResponseCaseData> respCaseData = mockStatic(ResponseCaseData.class)) {
+            respCaseData.when(ResponseCaseData::builder).thenReturn(builderSpy);
+
+            underTest.getResponseCaseData(caseDetailsMock, eventId, transform);
+        }
+
+        verify(builderSpy).deceasedAnyOtherNameOnWill(YES);
+        verify(builderSpy).deceasedAliasFirstNameOnWill(WILL_ALIAS_FN);
+        verify(builderSpy).deceasedAliasLastNameOnWill(WILL_ALIAS_LN);
+
+        verify(builderSpy, never()).deceasedAliasNamesList(any());
+
+        verify(builderSpy, never()).solsDeceasedAliasNamesList(argThat(expAliasMatcher.invert()));
+        verify(builderSpy).solsDeceasedAliasNamesList(argThat(expAliasMatcher));
+    }
+
+    @Test
     void neverAddNonSolsAliasesToBuilder() {
         final var builder = ResponseCaseData.builder();
         final var builderSpy = spy(builder);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
@@ -81,8 +82,10 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -95,6 +98,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -314,6 +318,43 @@ class CallbackResponseTransformerTest {
     private static final LocalDateTime dateTime = LocalDateTime.of(2024, 1, 1, 1, 1, 1, 1);
     private static final String DEFAULT_DATE_OF_DEATHTYPE = "diedOn";
     private static final String RESPONSE_CONTENT = "I responded";
+
+    private static final String WILL_ALIAS_FN = "WillFN";
+    private static final String WILL_ALIAS_LN = "WillLN";
+    private static final String WILL_ALIAS = WILL_ALIAS_FN + " " + WILL_ALIAS_LN;
+    private static final ProbateAliasName WILL_PROBATE_ALIAS_NAME = ProbateAliasName.builder()
+            .forenames(WILL_ALIAS_FN)
+            .lastName(WILL_ALIAS_LN)
+            .build();
+    private static final CollectionMember<ProbateAliasName> WILL_PROBATE_ALIAS_NAME_CM = new CollectionMember<>(
+            WILL_PROBATE_ALIAS_NAME);
+    private static final AliasName WILL_ALIAS_NAME = AliasName.builder().solsAliasname(WILL_ALIAS).build();
+    private static final CollectionMember<AliasName> WILL_ALIAS_NAME_CM = new CollectionMember<>(WILL_ALIAS_NAME);
+
+    private static final String DEC_ALIAS_FN = "DecAliasFN";
+    private static final String DEC_ALIAS_LN = "DecAliasLN";
+    private static final String DEC_ALIAS = DEC_ALIAS_FN + " " + DEC_ALIAS_LN;
+    private static final ProbateAliasName DEC_PROBATE_ALIAS_NAME = ProbateAliasName.builder()
+            .forenames(DEC_ALIAS_FN)
+            .lastName(DEC_ALIAS_LN)
+            .build();
+    private static final CollectionMember<ProbateAliasName> DEC_PROBATE_ALIAS_NAME_CM = new CollectionMember<>(
+            DEC_PROBATE_ALIAS_NAME);
+    private static final AliasName DEC_ALIAS_NAME = AliasName.builder().solsAliasname(DEC_ALIAS).build();
+    private static final CollectionMember<AliasName> DEC_ALIAS_NAME_CM = new CollectionMember<>(DEC_ALIAS_NAME);
+
+    private static final String SOL_DEC_ALIAS_FN = "SolDecAliasFN";
+    private static final String SOL_DEC_ALIAS_LN = "SolDecAliasLN";
+    private static final String SOL_DEC_ALIAS = SOL_DEC_ALIAS_FN + " " + SOL_DEC_ALIAS_LN;
+    private static final ProbateAliasName SOL_DEC_PROBATE_ALIAS_NAME = ProbateAliasName.builder()
+            .forenames(SOL_DEC_ALIAS_FN)
+            .lastName(SOL_DEC_ALIAS_LN)
+            .build();
+    private static final CollectionMember<ProbateAliasName> SOL_DEC_PROBATE_ALIAS_NAME_CM = new CollectionMember<>(
+            SOL_DEC_PROBATE_ALIAS_NAME);
+    private static final AliasName SOL_DEC_ALIAS_NAME = AliasName.builder().solsAliasname(SOL_DEC_ALIAS).build();
+    private static final CollectionMember<AliasName> SOL_DEC_ALIAS_NAME_CM = new CollectionMember<>(SOL_DEC_ALIAS_NAME);
+
     private List<CaseMatch> caseMatches = new ArrayList<>();
 
     @Mock
@@ -4732,5 +4773,195 @@ class CallbackResponseTransformerTest {
 
     private String format(DateTimeFormatter formatter, ResponseCaseData caseData, int ind) {
         return formatter.format(caseData.getRegistrarDirections().get(ind).getValue().getAddedDateTime());
+    }
+
+    @Test
+    void testConvertWillAlias_sameOnWillNull() {
+        final Long caseRef = 1L;
+        final String nameSameOnWill = null;
+        final String foreNames = WILL_ALIAS_FN;
+        final String lastName = WILL_ALIAS_LN;
+
+        final var res = underTest.convertAliasOnWillToSolsDecAliasList(
+                caseRef,
+                nameSameOnWill,
+                foreNames,
+                lastName);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted will aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertWillAlias_sameOnWillYes() {
+        final Long caseRef = 1L;
+        final String otherNameOnWill = YES;
+        final String foreNames = WILL_ALIAS_FN;
+        final String lastName = WILL_ALIAS_LN;
+
+        final var res = underTest.convertAliasOnWillToSolsDecAliasList(
+                caseRef,
+                otherNameOnWill,
+                foreNames,
+                lastName);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted will aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertWillAlias_sameOnWillNo_fnNull_lnPresent() {
+        final Long caseRef = 1L;
+        final String otherNameOnWill = NO;
+        final String foreNames = null;
+        final String lastName = WILL_ALIAS_LN;
+
+        final var res = underTest.convertAliasOnWillToSolsDecAliasList(
+                caseRef,
+                otherNameOnWill,
+                foreNames,
+                lastName);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted will aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertWillAlias_sameOnWillNo_fnPresent_lnNull() {
+        final Long caseRef = 1L;
+        final String otherNameOnWill = NO;
+        final String foreNames = WILL_ALIAS_FN;
+        final String lastName = null;
+
+        final var res = underTest.convertAliasOnWillToSolsDecAliasList(
+                caseRef,
+                otherNameOnWill,
+                foreNames,
+                lastName);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted will aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertWillAlias_sameOnWillNo_fnPresent_lnPresent() {
+        final Long caseRef = 1L;
+        final String otherNameOnWill = NO;
+        final String foreNames = WILL_ALIAS_FN;
+        final String lastName = WILL_ALIAS_LN;
+
+        final var res = underTest.convertAliasOnWillToSolsDecAliasList(
+                caseRef,
+                otherNameOnWill,
+                foreNames,
+                lastName);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(1, res.size(), "Expected converted will aliases to have one entry"));
+        assertions.add(() -> assertTrue(res.contains(WILL_ALIAS_NAME_CM), "Expected will alias present"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertDecAliases_null() {
+        final List<CollectionMember<ProbateAliasName>> aliases = null;
+
+        final var res = underTest.convertDecAliasesSolsDecAliasList(
+                aliases);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted will aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertDecAliases_empty() {
+        final List<CollectionMember<ProbateAliasName>> aliases = List.of();
+
+        final var res = underTest.convertDecAliasesSolsDecAliasList(
+                aliases);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(0, res.size(), "Expected converted dec aliases to be empty"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertDecAliases_one() {
+        final List<CollectionMember<ProbateAliasName>> aliases = List.of(
+                DEC_PROBATE_ALIAS_NAME_CM);
+
+        final var res = underTest.convertDecAliasesSolsDecAliasList(
+                aliases);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(1, res.size(), "Expected converted dec aliases to be have one entry"));
+        assertions.add(() -> assertTrue(res.contains(DEC_ALIAS_NAME_CM), "Expected dec alias present"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertDecAliases_two() {
+        final List<CollectionMember<ProbateAliasName>> aliases = List.of(
+                DEC_PROBATE_ALIAS_NAME_CM,
+                WILL_PROBATE_ALIAS_NAME_CM);
+
+        final var res = underTest.convertDecAliasesSolsDecAliasList(
+                aliases);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(2, res.size(), "Expected converted will aliases to have two entries"));
+        assertions.add(() -> assertTrue(res.contains(DEC_ALIAS_NAME_CM), "Expected dec alias present"));
+        assertions.add(() -> assertTrue(res.contains(WILL_ALIAS_NAME_CM), "Expected will alias present"));
+
+        assertAll(assertions);
+    }
+
+    @Test
+    void testConvertDecAliases_twoDuplicate() {
+        final List<CollectionMember<ProbateAliasName>> aliases = List.of(
+                DEC_PROBATE_ALIAS_NAME_CM,
+                DEC_PROBATE_ALIAS_NAME_CM);
+
+        final var res = underTest.convertDecAliasesSolsDecAliasList(
+                aliases);
+
+        final Collection<Executable> assertions = new HashSet<>();
+
+        assertions.add(() -> assertNotNull(res, "Expected non-null response"));
+        assertions.add(() -> assertEquals(1, res.size(), "Expected converted dec aliases to have one entry"));
+        assertions.add(() -> assertTrue(res.contains(DEC_ALIAS_NAME_CM), "Expected will alias present"));
+
+        assertAll(assertions);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -54,6 +54,7 @@ import uk.gov.hmcts.probate.model.fee.FeesResponse;
 import uk.gov.hmcts.probate.model.payments.pba.OrganisationEntityResponse;
 import uk.gov.hmcts.probate.service.ExceptedEstateDateOfDeathChecker;
 import uk.gov.hmcts.probate.service.ExecutorsApplyingNotificationService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.StateChangeService;
 import uk.gov.hmcts.probate.service.organisations.OrganisationsRetrievalService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.ExecutorListMapperService;
@@ -555,6 +556,9 @@ class CallbackResponseTransformerTest {
     private Iht400421Defaulter iht400421Defaulter;
     @Mock
     Document coversheetMock;
+
+    @Mock
+    private FeatureToggleService featureToggleService;
 
     @BeforeEach
     public void setup() {
@@ -4889,6 +4893,8 @@ class CallbackResponseTransformerTest {
                 DEC_ALIAS_NAME_CM,
                 SOL_DEC_ALIAS_NAME_CM);
         final AliasMatcher expAliasMatcher = new AliasMatcher(expAliases);
+
+        when(featureToggleService.enableNewAliasTransformation()).thenReturn(true);
 
         try (MockedStatic<ResponseCaseData> respCaseData = mockStatic(ResponseCaseData.class)) {
             respCaseData.when(ResponseCaseData::builder).thenReturn(builderSpy);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPB-4388](https://tools.hmcts.net/jira/browse/DTSPB-4388)

### Change description ###
Alter the way we mangle our data in the response path. We currently add the `deceasedAliasOnWill` values into the `solsDeceasedAliasNamesList` every time we update the case. With this change we only do that once, and then drop the relevant fields so they aren't present any more. This should stop the ongoing issues with the unmodifiable to the caseworker `deceasedAliasOnWill` fields being re-added to the `solsDeceasedAliasNamesList` every time they are removed. It does mean that we're essentially throwing away some context here though since it changes from being an alias on the will to being just a generic alias (and we lose the split forenames + surname and just get a single text field).

This is arguably the simplest way to resolve the issue we currently have, but I think we ultimately need to think about how we are handling these duplicated fields etc. especially with regards to document generation.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
