### PR TITLE
Adapt existing changes to use the preview html rather than the pre-markdown body

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ def versions = [
         documentClient                  : '1.8.1',
         elasticSearchVersion            : '7.17.24',
         hmctsJavaLogging                : '6.1.7',
+        jsoup                           : '1.18.3',
         jacksonDatabind                 : '2.17.1',
         lombok                          : '1.18.36',
         mapStruct                       : '1.2.0.Final',
@@ -263,6 +264,7 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.4'
   implementation group: 'org.mapstruct', name: 'mapstruct-jdk8', version: versions.mapStruct
   implementation group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapStruct
+  implementation group: 'org.jsoup', name: 'jsoup', version: versions.jsoup
 
   // Notifications client API
   implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.2.1-RELEASE'

--- a/src/integrationTest/java/uk/gov/hmcts/probate/service/NotificationServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/service/NotificationServiceIT.java
@@ -2150,8 +2150,7 @@ class NotificationServiceIT {
     @Test
     void verifyEmailPreview()
             throws NotificationClientException {
-
-        when(pdfManagementService.generateDocmosisDocumentAndUpload(any(), any())).thenReturn(Document.builder()
+        when(pdfManagementService.generateAndUpload(any(SentEmail.class), any())).thenReturn(Document.builder()
                 .documentFileName(SENT_EMAIL_FILE_NAME).build());
         CaseDetails caseDetails = new CaseDetails(CaseData.builder()
                 .applicationType(SOLICITOR)
@@ -2166,6 +2165,6 @@ class NotificationServiceIT {
                 .build(), LAST_MODIFIED, ID);
         notificationService.emailPreview(caseDetails);
 
-        verify(pdfManagementService).generateDocmosisDocumentAndUpload(any(), eq(SENT_EMAIL));
+        verify(pdfManagementService).generateAndUpload(any(SentEmail.class), eq(SENT_EMAIL));
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -419,14 +419,14 @@ public class NotificationService {
 
     private Document getGeneratedDocument(TemplatePreview response, String emailAddress,
                                           DocumentType docType) {
+        final String previewXhtml = pdfManagementService.rerenderAsXhtml(response.getHtml().orElseThrow());
         SentEmail sentEmail = SentEmail.builder()
                 .sentOn(LocalDateTime.now().format(formatter))
                 .to(emailAddress)
                 .subject(response.getSubject().orElse(""))
-                .body(response.getBody())
+                .body(previewXhtml)
                 .build();
-        Map<String, Object> placeholders = sentEmailPersonalisationService.getPersonalisation(sentEmail);
-        return pdfManagementService.generateDocmosisDocumentAndUpload(placeholders, docType);
+        return pdfManagementService.generateAndUpload(sentEmail, docType);
     }
 
     public void startGrantDelayNotificationPeriod(CaseDetails caseDetails) {

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -47,6 +47,7 @@ import jakarta.validation.Valid;
 import uk.gov.service.notify.TemplatePreview;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementService.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.probate.service.template.pdf;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.probate.config.PDFServiceConfiguration;
@@ -181,5 +183,25 @@ public class PDFManagementService {
 
     public String getDecodedSignature() {
         return decryptedFileAsBase64String(pdfServiceConfiguration.getGrantSignatureEncryptedFile());
+    }
+
+    /** Converts an input HTML string to an XHTML string.
+     *
+     * This is needed because the underlying pdfGeneratorService uses an XML parser rather
+     * than an HTML parser.
+     *
+     * @param inputHtml an HTML string
+     * @return the input rendered as XHTML
+     */
+    public String rerenderAsXhtml(String inputHtml) {
+        final Safelist safelist = Safelist.relaxed();
+
+
+        final org.jsoup.nodes.Document.OutputSettings outputSettings = new org.jsoup.nodes.Document.OutputSettings()
+                .syntax(org.jsoup.nodes.Document.OutputSettings.Syntax.xml)
+                .charset(StandardCharsets.UTF_8)
+                .prettyPrint(false);
+
+        return Jsoup.clean(inputHtml, "", safelist, outputSettings);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/template/pdf/PDFManagementServiceTest.java
@@ -362,4 +362,14 @@ class PDFManagementServiceTest {
         assertEquals(BINARY_URL, response.getDocumentLink().getDocumentBinaryUrl());
         assertEquals(SELF_URL, response.getDocumentLink().getDocumentUrl());
     }
+
+    @Test
+    void testXhtmlReplacesBrTag() {
+        final String inputHtml = "<p>something</p><br><p>other</p>";
+        final String expectedXhtml = "<p>something</p><br /><p>other</p>";
+
+        final String actualXhtml = underTest.rerenderAsXhtml(inputHtml);
+
+        assertEquals(expectedXhtml, actualXhtml, "Expected result to have closed <br /> tag");
+    }
 }


### PR DESCRIPTION
Adds a handler method into the pdfManagementService to perform the HTML -> XHTML conversion, using Jsoup's `clean(...)` method to perform the conversion.
