### PR TITLE
DTSPB-4486 Improve Notify error reporting

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/probate/service/NotificationServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/service/NotificationServiceIT.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.probate.config.properties.registries.RegistriesProperties;
 import uk.gov.hmcts.probate.config.properties.registries.Registry;
 import uk.gov.hmcts.probate.exception.BadRequestException;
 import uk.gov.hmcts.probate.exception.InvalidEmailException;
+import uk.gov.hmcts.probate.exception.RequestInformationParameterException;
 import uk.gov.hmcts.probate.model.ApplicationType;
 import uk.gov.hmcts.probate.model.CaseType;
 import uk.gov.hmcts.probate.model.CaseOrigin;
@@ -2130,7 +2131,7 @@ class NotificationServiceIT {
 
     @Test
     void throwExceptionSendEmailWhenInvalidPersonalisationExists() {
-        NotificationClientException expectException =  assertThrows(NotificationClientException.class,
+        RequestInformationParameterException expectException =  assertThrows(RequestInformationParameterException.class,
                 () -> notificationService.sendEmail(CASE_STOPPED, markdownLinkCaseData));
         assertEquals(MARKDOWN_ERROR_MESSAGE, expectException.getMessage());
     }
@@ -2146,14 +2147,14 @@ class NotificationServiceIT {
                         .build())
                 .email("primary@probate-test.com")
                 .notification("Yes").build();
-        NotificationClientException expectException =  assertThrows(NotificationClientException.class,
+        RequestInformationParameterException expectException =  assertThrows(RequestInformationParameterException.class,
                 () -> notificationService.sendEmail(CASE_STOPPED_REQUEST_INFORMATION, markdownLinkCaseData));
         assertEquals(MARKDOWN_ERROR_MESSAGE, expectException.getMessage());
     }
 
     @Test
     void throwExceptionSendCaveatEmailWhenInvalidPersonalisationExists() {
-        NotificationClientException expectException =  assertThrows(NotificationClientException.class,
+        RequestInformationParameterException expectException =  assertThrows(RequestInformationParameterException.class,
                 () -> notificationService.sendCaveatEmail(GENERAL_CAVEAT_MESSAGE, markdownLinkCaveatData));
         assertEquals(MARKDOWN_ERROR_MESSAGE, expectException.getMessage());
     }
@@ -2172,7 +2173,7 @@ class NotificationServiceIT {
                         .build())
                 .email("primary@probate-test.com")
                 .notification("Yes").build();
-        NotificationClientException expectException =  assertThrows(NotificationClientException.class,
+        RequestInformationParameterException expectException =  assertThrows(RequestInformationParameterException.class,
                 () -> notificationService.sendEmailWithDocumentAttached(markdownLinkCaseData,
                         executorsApplyingNotification, REDECLARATION_SOT));
         assertEquals(MARKDOWN_ERROR_MESSAGE, expectException.getMessage());

--- a/src/main/java/uk/gov/hmcts/probate/controller/NotificationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/NotificationController.java
@@ -199,7 +199,8 @@ public class NotificationController {
     }
 
     @PostMapping(path = "/stopped-information-request")
-    public ResponseEntity<CallbackResponse> informationRequest(@RequestBody CallbackRequest callbackRequest) {
+    public ResponseEntity<CallbackResponse> informationRequest(
+            @RequestBody final CallbackRequest callbackRequest) throws NotificationClientException {
         Optional<UserInfo> caseworkerInfo = userInfoService.getCaseworkerInfo();
         return ResponseEntity.ok(informationRequestService.handleInformationRequest(callbackRequest, caseworkerInfo));
     }

--- a/src/main/java/uk/gov/hmcts/probate/exception/RequestInformationParameterException.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/RequestInformationParameterException.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.probate.exception;
+
+public class RequestInformationParameterException extends BusinessValidationException {
+    private static final String INVALID_PERSONALISATION_ERROR_MESSAGE =
+            "Markdown Link detected in case data, stop sending notification email.";
+
+    public RequestInformationParameterException() {
+        super(INVALID_PERSONALISATION_ERROR_MESSAGE, INVALID_PERSONALISATION_ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.probate.exception.model.ErrorResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponseStatus;
 import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
-import uk.gov.service.notify.NotificationClientException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +40,6 @@ class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
     public static final String SERVER_ERROR = "Server Error";
     public static final String CONNECTION_ERROR = "Connection error";
     public static final String UNAUTHORISED_DATA_EXTRACT_ERROR = "Unauthorised access to Data-Extract error";
-
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ErrorResponse> handle(BadRequestException exception) {
@@ -91,16 +89,6 @@ class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        return new ResponseEntity<>(errorResponse, headers, SERVICE_UNAVAILABLE);
-    }
-
-    @ExceptionHandler(value = NotificationClientException.class)
-    public ResponseEntity<ErrorResponse> handle(NotificationClientException exception) {
-        log.warn("Notification service exception", exception);
-        ErrorResponse errorResponse =
-            new ErrorResponse(SERVICE_UNAVAILABLE.value(), CLIENT_ERROR, exception.getMessage());
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
         return new ResponseEntity<>(errorResponse, headers, SERVICE_UNAVAILABLE);
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/exception/handler/NotificationClientExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/handler/NotificationClientExceptionHandler.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.probate.exception.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@ControllerAdvice
+public class NotificationClientExceptionHandler extends ResponseEntityExceptionHandler {
+    public static final String UNABLE_TO_SEND_EMAIL = "Unable to send email";
+
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public NotificationClientExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @ExceptionHandler(value = NotificationClientException.class)
+    public ResponseEntity<CallbackResponse> handle(NotificationClientException exception) {
+        log.warn("Notification service exception", exception);
+        final List<String> errors = List.copyOf(getNotifyErrors(exception.getMessage()));
+
+        final CallbackResponse errorResponse = CallbackResponse.builder()
+                .errors(errors)
+                .build();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(errorResponse);
+    }
+
+    /**
+     * This relies on the behaviour of NotifyClient#performPostRequest passing the connection's error stream as a json
+     * string into the exception message, so is liable to break.
+     */
+    private List<String> getNotifyErrors(final String exMessage) {
+        final String exJson = exMessage.replaceFirst("[^{]*", "");
+
+        final List<String> errors = new ArrayList<>();
+        errors.add(UNABLE_TO_SEND_EMAIL);
+
+        final JsonNode outerJson;
+        try {
+            outerJson = objectMapper.readTree(exJson);
+        } catch (JsonProcessingException e) {
+            return errors;
+        }
+
+        if (!outerJson.isObject()) {
+            return errors;
+        }
+        if (!outerJson.has("errors") || !outerJson.get("errors").isArray()) {
+            return errors;
+        }
+
+        final JsonNode errorsJson = outerJson.get("errors");
+        for (final JsonNode errorJson : errorsJson) {
+            if (errorJson.isObject() && errorJson.has("message") && errorJson.get("message").isTextual()) {
+                final String message = errorJson.get("message").asText();
+                errors.add(message);
+            }
+        }
+        return errors;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/InformationRequestCorrespondenceService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/InformationRequestCorrespondenceService.java
@@ -18,7 +18,7 @@ public class InformationRequestCorrespondenceService {
 
     private final NotificationService notificationService;
 
-    public List<Document> emailInformationRequest(CaseDetails caseDetails) {
+    public List<Document> emailInformationRequest(CaseDetails caseDetails) throws NotificationClientException {
         try {
             final Document notification = notificationService.sendEmail(CASE_STOPPED_REQUEST_INFORMATION, caseDetails);
             log.info("Successful response for request for information email for case id {} ", caseDetails.getId());

--- a/src/main/java/uk/gov/hmcts/probate/service/InformationRequestCorrespondenceService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/InformationRequestCorrespondenceService.java
@@ -19,14 +19,8 @@ public class InformationRequestCorrespondenceService {
     private final NotificationService notificationService;
 
     public List<Document> emailInformationRequest(CaseDetails caseDetails) throws NotificationClientException {
-        try {
-            final Document notification = notificationService.sendEmail(CASE_STOPPED_REQUEST_INFORMATION, caseDetails);
-            log.info("Successful response for request for information email for case id {} ", caseDetails.getId());
-            return List.of(notification);
-        } catch (NotificationClientException e) {
-            log.error(e.getMessage());
-            // this feels wrong - do we not want to alert the caller that the email sending has failed?
-            return List.of();
-        }
+        final Document notification = notificationService.sendEmail(CASE_STOPPED_REQUEST_INFORMATION, caseDetails);
+        log.info("Successful response for request for information email for case id {} ", caseDetails.getId());
+        return List.of(notification);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/InformationRequestService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/InformationRequestService.java
@@ -26,8 +26,9 @@ public class InformationRequestService {
     private final CallbackResponseTransformer callbackResponseTransformer;
     private final EmailAddressNotifyApplicantValidationRule emailAddressNotifyApplicantValidationRule;
 
-    public CallbackResponse handleInformationRequest(CallbackRequest callbackRequest,
-                                                     Optional<UserInfo> caseworkerInfo) {
+    public CallbackResponse handleInformationRequest(
+            final CallbackRequest callbackRequest,
+            final Optional<UserInfo> caseworkerInfo) throws NotificationClientException {
         CaseData caseData = callbackRequest.getCaseDetails().getData();
         CCDData dataForEmailAddress = CCDData.builder()
                 .applicationType(caseData.getApplicationType().name())

--- a/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/NotificationService.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.probate.config.properties.registries.RegistriesProperties;
 import uk.gov.hmcts.probate.config.properties.registries.Registry;
 import uk.gov.hmcts.probate.exception.BadRequestException;
 import uk.gov.hmcts.probate.exception.InvalidEmailException;
+import uk.gov.hmcts.probate.exception.RequestInformationParameterException;
 import uk.gov.hmcts.probate.model.ApplicationType;
 import uk.gov.hmcts.probate.model.CaseOrigin;
 import uk.gov.hmcts.probate.model.Constants;
@@ -76,8 +77,6 @@ public class NotificationService {
     private static final String APPLICATION_TYPE = "applicationType";
     private static final String PERSONALISATION_SOT_LINK = "sot_link";
     private static final DateTimeFormatter RELEASE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final String INVALID_PERSONALISATION_ERROR_MESSAGE =
-            "Markdown Link detected in case data, stop sending notification email.";
     private static final List<String> PA_DRAFT_STATE_LIST = List.of(STATE_PENDING, STATE_CASE_PAYMENT_FAILED);
 
     private final EmailAddresses emailAddresses;
@@ -676,7 +675,7 @@ public class NotificationService {
 
     CommonNotificationResult doCommonNotificationServiceHandling(
             final Map<String, ?> personalisation,
-            final Long caseId) throws NotificationClientException {
+            final Long caseId) throws RequestInformationParameterException {
         final PersonalisationValidationRule.PersonalisationValidationResult validationResult =
                 personalisationValidationRule.validatePersonalisation(personalisation);
         final Map<String, String> invalidFields = validationResult.invalidFields();
@@ -685,7 +684,7 @@ public class NotificationService {
         if (!invalidFields.isEmpty()) {
             log.error("Personalisation validation failed for case: {} fields: {}",
                     caseId, invalidFields);
-            throw new NotificationClientException(INVALID_PERSONALISATION_ERROR_MESSAGE);
+            throw new RequestInformationParameterException();
         } else if (!htmlFields.isEmpty()) {
             log.info("Personalisation validation found HTML for case: {} fields: {}",
                     caseId, validationResult.htmlFields());

--- a/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.probate.exception.ClientException;
 import uk.gov.hmcts.probate.exception.ConnectionException;
 import uk.gov.hmcts.probate.exception.NotFoundException;
 import uk.gov.hmcts.probate.exception.OCRMappingException;
+import uk.gov.hmcts.probate.exception.RequestInformationParameterException;
 import uk.gov.hmcts.probate.exception.SocketException;
 import uk.gov.hmcts.probate.exception.TextFileBuilderException;
 import uk.gov.hmcts.probate.exception.model.ErrorResponse;
@@ -22,6 +23,7 @@ import uk.gov.service.notify.NotificationClientException;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -189,5 +191,20 @@ class DefaultExceptionHandlerTest {
         assertEquals(OK, response.getStatusCode());
         assertEquals(1, response.getBody().getErrors().size());
         assertEquals(EXCEPTION_MESSAGE, response.getBody().getErrors().get(0));
+    }
+
+    @Test
+    void shouldReturnMarkdownError() {
+        RequestInformationParameterException ex = mock(RequestInformationParameterException.class);
+        when(ex.getMessage()).thenReturn("");
+        when(ex.getUserMessage()).thenReturn(EXCEPTION_MESSAGE);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(ex);
+
+        assertEquals(OK, response.getStatusCode(),
+                "Expected HTTP OK from RequestInformationParameterException handler");
+        assertEquals(1, response.getBody().getErrors().size(), "Expected one error");
+        assertEquals(EXCEPTION_MESSAGE, response.getBody().getErrors().get(0),
+                "Expected error to be extracted from exception");
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.probate.exception.model.ErrorResponse;
 import uk.gov.hmcts.probate.exception.model.FieldErrorResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
 import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
-import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Arrays;
 
@@ -43,9 +42,6 @@ class DefaultExceptionHandlerTest {
 
     @Mock
     private BadRequestException badRequestException;
-
-    @Mock
-    private NotificationClientException notificationClientException;
 
     @Mock
     private BusinessValidationException businessValidationException;
@@ -112,17 +108,6 @@ class DefaultExceptionHandlerTest {
 
         assertEquals(bve1Mock, response.getBody().getFieldErrors().get(0));
         assertEquals(bve2Mock, response.getBody().getFieldErrors().get(1));
-    }
-
-    @Test
-    void shouldReturnNotificationClientException() {
-        when(notificationClientException.getMessage()).thenReturn(EXCEPTION_MESSAGE);
-
-        ResponseEntity<ErrorResponse> response = underTest.handle(notificationClientException);
-
-        assertEquals(SERVICE_UNAVAILABLE, response.getStatusCode());
-        assertEquals(DefaultExceptionHandler.CLIENT_ERROR, response.getBody().getError());
-        assertEquals(EXCEPTION_MESSAGE, response.getBody().getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/exception/handler/NotificationClientExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/exception/handler/NotificationClientExceptionHandlerTest.java
@@ -1,0 +1,156 @@
+package uk.gov.hmcts.probate.exception.handler;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.probate.model.ccd.raw.response.CallbackResponse;
+import uk.gov.service.notify.NotificationClientException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+
+public class NotificationClientExceptionHandlerTest {
+    NotificationClientExceptionHandler underTest;
+
+    ObjectMapper objectMapperSpy;
+
+    @BeforeEach
+    void setUp() {
+        objectMapperSpy = spy(ObjectMapper.class);
+        underTest = new NotificationClientExceptionHandler(objectMapperSpy);
+    }
+
+    @Test
+    void shouldReturnNotificationClientException() {
+        final String firstError = "first_error";
+        final String secondError = "second_error";
+        final String exceptMsg = new StringBuilder()
+                .append("Status code: 400 ")
+                .append("{\"errors\":[")
+                .append("{\"message\":\"").append(firstError).append("\"},")
+                .append("{\"message\":\"").append(secondError).append("\"}")
+                .append("]}")
+                .toString();
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(3, response.getBody().getErrors().size(), "Expected three errors");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                "expected first error to be from handler");
+        assertEquals(firstError, response.getBody().getErrors().get(1),
+                "expected second error to match from exception message");
+        assertEquals(secondError, response.getBody().getErrors().get(2),
+                "expected third error to match from exception message");
+    }
+
+    @Test
+    void shouldReturnNotificationClientExceptionWhenInvalidJson() throws JsonProcessingException {
+        final String exceptMsg = "";
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        when(objectMapperSpy.readTree(anyString())).thenThrow(new JsonParseException(exceptMsg));
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(1, response.getBody().getErrors().size(),
+                "Expected only one error on json parse failure");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                "expected first error to be from handler");
+    }
+
+    @Test
+    void shouldReturnNotificationClientExceptionWhenJsonArray() throws JsonProcessingException {
+        final String exceptMsg = "[]";
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(1, response.getBody().getErrors().size(),
+                "Expected only one error on json parse failure");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                "expected first error to be from handler");
+    }
+
+    @Test
+    void shouldReturnNotificationClientExceptionWhenJsonMissingErrors() throws JsonProcessingException {
+        final String firstError = "first_error";
+        final String secondError = "second_error";
+        final String exceptMsg = "{}";
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(1, response.getBody().getErrors().size(),
+                "Expected only one error on json parse failure");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                "expected first error to be from handler");
+    }
+
+    @Test
+    void shouldReturnNotificationClientExceptionWhenJsonErrorsIsObject() throws JsonProcessingException {
+        final String firstError = "first_error";
+        final String secondError = "second_error";
+        final String exceptMsg = "{\"errors\":{}}";
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(1, response.getBody().getErrors().size(),
+                "Expected only one error on json parse failure");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                "expected first error to be from handler");
+    }
+
+    @Test
+    void shouldReturnNotificationClientExceptionWhenJsonErrorsContainsUnexpected() throws JsonProcessingException {
+        final String firstError = "first_error";
+        final String secondError = "second_error";
+        final String exceptMsg = new StringBuilder()
+                .append("{\"errors\":[")
+                .append("{\"message\":\"").append(firstError).append("\"},")
+                .append("[],")
+                .append("{},")
+                .append("{\"message\": 0},")
+                .append("{\"message\":\"").append(secondError).append("\"}")
+                .append("]}")
+                .toString();
+
+        NotificationClientException notificationClientException = mock(NotificationClientException.class);
+        when(notificationClientException.getMessage()).thenReturn(exceptMsg);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(notificationClientException);
+
+
+        assertEquals(OK, response.getStatusCode(), "Expected HTTP OK (200) response status");
+        assertEquals(3, response.getBody().getErrors().size(), "Expected three errors");
+        assertEquals(NotificationClientExceptionHandler.UNABLE_TO_SEND_EMAIL, response.getBody().getErrors().get(0),
+                        "expected first error to be from handler");
+        assertEquals(firstError, response.getBody().getErrors().get(1),
+                        "expected second error to match from exception message");
+        assertEquals(secondError, response.getBody().getErrors().get(2),
+                        "expected third error to match from exception message");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/InformationRequestServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/InformationRequestServiceTest.java
@@ -73,7 +73,7 @@ class InformationRequestServiceTest {
     }
 
     @Test
-    void testEmailRequestReturnsSentEmailDocumentSuccessfully() {
+    void testEmailRequestReturnsSentEmailDocumentSuccessfully() throws NotificationClientException {
         CollectionMember<Document> documentCollectionMember =
             new CollectionMember<>(Document.builder().documentType(DocumentType.SENT_EMAIL).build());
         documentList = new ArrayList<>();
@@ -102,7 +102,7 @@ class InformationRequestServiceTest {
     }
 
     @Test
-    void testEmailRequestReturnsErrorWhenNoEmailProvided() {
+    void testEmailRequestReturnsErrorWhenNoEmailProvided() throws NotificationClientException {
         caseData = CaseData.builder()
                 .applicationType(ApplicationType.PERSONAL)
                 .build();

--- a/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/NotificationServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.probate.config.notifications.EmailAddresses;
 import uk.gov.hmcts.probate.config.notifications.NotificationTemplates;
 import uk.gov.hmcts.probate.config.properties.registries.RegistriesProperties;
+import uk.gov.hmcts.probate.exception.RequestInformationParameterException;
 import uk.gov.hmcts.probate.service.documentmanagement.DocumentManagementService;
 import uk.gov.hmcts.probate.service.notification.CaveatPersonalisationService;
 import uk.gov.hmcts.probate.service.notification.GrantOfRepresentationPersonalisationService;
@@ -22,7 +23,6 @@ import uk.gov.hmcts.probate.validator.PersonalisationValidationRule;
 import uk.gov.hmcts.probate.validator.PersonalisationValidationRule.PersonalisationValidationResult;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.service.notify.NotificationClient;
-import uk.gov.service.notify.NotificationClientException;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,12 +98,13 @@ class NotificationServiceTest {
         when(personalisationValidationRuleMock.validatePersonalisation(dummyPersonalisation))
                 .thenReturn(mockResult);
 
-        assertThrows(NotificationClientException.class, () ->
+        assertThrows(RequestInformationParameterException.class, () ->
                 notificationService.doCommonNotificationServiceHandling(dummyPersonalisation, dummyCaseId));
     }
 
     @Test
-    void givenPersonalisationWithHtml_whenCommonValidation_thenReturnsHtmlFound() throws NotificationClientException {
+    void givenPersonalisationWithHtml_whenCommonValidation_thenReturnsHtmlFound()
+            throws RequestInformationParameterException {
         final Map<String, ?> dummyPersonalisation = Collections.emptyMap();
         final Long dummyCaseId = 1L;
 
@@ -120,7 +121,8 @@ class NotificationServiceTest {
     }
 
     @Test
-    void givenPersonalisationWithNoIssue_whenCommonValidation_thenReturnsAllOk() throws NotificationClientException {
+    void givenPersonalisationWithNoIssue_whenCommonValidation_thenReturnsAllOk()
+            throws RequestInformationParameterException {
         final Map<String, ?> dummyPersonalisation = Collections.emptyMap();
         final Long dummyCaseId = 1L;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4486](https://tools.hmcts.net/jira/browse/DTSPB-4486)


### Change description ###
Adds a new exception type for non-notify email errors. moves the Notify exception handler into its own class.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
