### PR TITLE
Add text file builder error handling.

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/exception/TextFileBuilderException.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/TextFileBuilderException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.probate.exception;
+
+public class TextFileBuilderException extends RuntimeException {
+    public TextFileBuilderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandler.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.probate.exception.ConnectionException;
 import uk.gov.hmcts.probate.exception.NotFoundException;
 import uk.gov.hmcts.probate.exception.OCRMappingException;
 import uk.gov.hmcts.probate.exception.SocketException;
+import uk.gov.hmcts.probate.exception.TextFileBuilderException;
 import uk.gov.hmcts.probate.exception.model.ErrorResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponseStatus;
@@ -131,6 +132,15 @@ class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
         ValidationResponse validationResponse =
             ValidationResponse.builder().status(ValidationResponseStatus.ERRORS).errors(errors).build();
         return ResponseEntity.ok(validationResponse);
+    }
+
+    @ExceptionHandler(TextFileBuilderException.class)
+    public ResponseEntity<CallbackResponse> handle(TextFileBuilderException exception) {
+        log.error("Error from TestFileBuilderService", exception);
+
+        List<String> errors = List.of(exception.getMessage());
+        CallbackResponse callbackResponse = CallbackResponse.builder().errors(errors).build();
+        return ResponseEntity.ok(callbackResponse);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/filebuilder/HmrcFileService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/filebuilder/HmrcFileService.java
@@ -53,7 +53,7 @@ public class HmrcFileService extends BaseFileService {
 
     public File createHmrcFile(List<ReturnedCaseDetails> ccdCases, String fileName) {
         ImmutableList.Builder<String> fileData = prepareFileData(ccdCases, fileName);
-        return textFileBuilderService.createFile(fileData.build(), DELIMITER, fileName);
+        return textFileBuilderService.createFile(fileData.build(), DELIMITER, fileName, "HMRC");
     }
 
     private ImmutableList.Builder<String> prepareFileData(List<ReturnedCaseDetails> ccdCases, String fileName) {

--- a/src/main/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/filebuilder/IronMountainFileService.java
@@ -32,7 +32,7 @@ public class IronMountainFileService extends BaseFileService {
             prepareData(ccdCase.getId(), ccdCase.getData(), fileData);
         }
         log.info("Created IronMountain file=" + fileName);
-        return textFileBuilderService.createFile(fileData.build(), DELIMITER, fileName);
+        return textFileBuilderService.createFile(fileData.build(), DELIMITER, fileName, "IronMountain");
     }
 
     private void prepareData(Long id, CaseData data, ImmutableList.Builder<String> fileData) {

--- a/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/exception/handler/DefaultExceptionHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.probate.exception.ConnectionException;
 import uk.gov.hmcts.probate.exception.NotFoundException;
 import uk.gov.hmcts.probate.exception.OCRMappingException;
 import uk.gov.hmcts.probate.exception.SocketException;
+import uk.gov.hmcts.probate.exception.TextFileBuilderException;
 import uk.gov.hmcts.probate.exception.model.ErrorResponse;
 import uk.gov.hmcts.probate.exception.model.FieldErrorResponse;
 import uk.gov.hmcts.probate.model.ccd.ocr.ValidationResponse;
@@ -177,5 +178,16 @@ class DefaultExceptionHandlerTest {
         assertEquals(OK, response.getStatusCode());
         assertEquals(1, response.getBody().getErrors().size());
         assertEquals("Message", response.getBody().getErrors().get(0));
+    }
+
+    @Test
+    void shouldReturnTextFileBuilderException() {
+        final TextFileBuilderException ex = new TextFileBuilderException(EXCEPTION_MESSAGE, null);
+
+        ResponseEntity<CallbackResponse> response = underTest.handle(ex);
+
+        assertEquals(OK, response.getStatusCode());
+        assertEquals(1, response.getBody().getErrors().size());
+        assertEquals(EXCEPTION_MESSAGE, response.getBody().getErrors().get(0));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/filebuilder/TextFileBuilderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/filebuilder/TextFileBuilderServiceTest.java
@@ -46,7 +46,7 @@ class TextFileBuilderServiceTest {
     }
 
     private BufferedReader createFile(String fileName) throws IOException {
-        File file = textFileBuilderService.createFile(data, "|", fileName);
+        File file = textFileBuilderService.createFile(data, "|", fileName, "TEST");
         file.deleteOnExit();
         FileReader reader = new FileReader(file);
         return new BufferedReader(reader);

--- a/src/test/java/uk/gov/hmcts/probate/util/diagrams/plantuml/BuildStateDiagram.java
+++ b/src/test/java/uk/gov/hmcts/probate/util/diagrams/plantuml/BuildStateDiagram.java
@@ -133,7 +133,7 @@ class BuildStateDiagram {
         String footer = "@enduml";
         allRows.add(footer);
         textFileBuilderService.createFile(allRows, ",", CASE_TYPE_PREFIX + caseType
-                + "_" + filteredByRoleName + "_state.txt");
+                + "_" + filteredByRoleName + "_state.txt", "BuildStateDiagram");
     }
 
     private List<String> getAllInformationRows(Event event) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4552](https://tools.hmcts.net/jira/browse/DTSPB-4552)

### Change description ###
Currently if there's any Exception the write continues blindly on. This seems less than ideal, and has caused at least one reported failure.

This also makes the TestFileBuilderService thread safe which it was not previously.

As best I can tell all the 'real' uses (i.e. those not in the tests) only actually care about the String content of the file, so it seems like we could skip putting these files into the filesystem and solve a number of problems?

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
