### PR TITLE
Resolve bootWithCcd authentication failure issue.

### DIFF
--- a/bin/variables/load-local-environment-variables.sh
+++ b/bin/variables/load-local-environment-variables.sh
@@ -48,6 +48,7 @@ echo "SOL_USER_EMAIL=$(az keyvault secret show --vault-name probate-aat -o tsv -
 echo "SOL_USER_PASSWORD=$(az keyvault secret show --vault-name probate-aat -o tsv --query value --name solicitorUserPass)" >> .aat-env
 echo "SOL2_USER_EMAIL=$(az keyvault secret show --vault-name probate-aat -o tsv --query value --name solicitor2UserEmail)" >> .aat-env
 echo "SOL2_USER_PASSWORD=$(az keyvault secret show --vault-name probate-aat -o tsv --query value --name solicitor2UserPass)" >> .aat-env
+echo "PROBATE_NOTIFY_KEY="$(az keyvault secret show --vault-name probate-aat -o tsv --query value --name probate-bo-govNotifyApiKey)" >> .aat-env
 
 # xui variables fetched from rpx-aat vault:
 echo "XUI_SYSTEM_USER_NAME=$(az keyvault secret show --vault-name rpx-aat -o tsv --query value --name system-user-name)" >> .aat-env

--- a/build.gradle
+++ b/build.gradle
@@ -496,6 +496,7 @@ bootWithCCD {
   environment 'PROBATE_POSTGRESQL_PORT', '6432'
   environment 'PROBATE_POSTGRESQL_USER', 'postgres'
   environment 'PROBATE_POSTGRESQL_PASSWORD', 'postgres'
+  environment 'CASE_DOCUMENT_S2S_AUTHORISED_SERVICES', 'ccd_case_document_am_api,ccd_gw,xui_webapp,ccd_data,bulk_scan_processor,em_npa_app,fprl_dgs_api,dg_docassembly_api,cmc_claim_store,civil_service,civil_general_applications,bulk_scan_orchestrator,ethos_repl_service,et_cos,nfdiv_case_api,divorce_frontend,probate_backend'
 
   if (new Boolean(System.getenv('USE_LOCAL_SUPPORT_SERVICES'))) {
     dependsOn buildBackOfficeXlsx


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
This adds configuration to set the permitted services for the document-am-api . These were the requests which were causing the generation of the legal statement (i think?) to fail. This should hopefully permit more use of the cftlib environment for local development work.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
