### PR TITLE
DTSPB-4647 Add flag to disable verification in legal statement amend

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/probate/controller/DocumentControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/controller/DocumentControllerIT.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.request.CaseDetails;
 import uk.gov.hmcts.probate.model.ccd.raw.response.ResponseCaseData;
 import uk.gov.hmcts.probate.model.ccd.willlodgement.request.WillLodgementCallbackRequest;
 import uk.gov.hmcts.probate.security.SecurityUtils;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.NotificationService;
 import uk.gov.hmcts.probate.service.DocumentService;
 import uk.gov.hmcts.probate.service.BulkPrintService;
@@ -141,6 +142,9 @@ class DocumentControllerIT {
     @MockBean
     private CaseDocumentClient caseDocumentClient;
 
+    @MockBean
+    private FeatureToggleService featureToggleService;
+
     @BeforeEach
     public void setUp() throws NotificationClientException {
         final Document document = Document.builder()
@@ -234,6 +238,8 @@ class DocumentControllerIT {
                 .thenCallRealMethod();
 
         doReturn(CASEWORKER_USERINFO).when(userInfoService).getCaseworkerInfo();
+
+        when(featureToggleService.enableAmendLegalStatementFiletypeCheck()).thenReturn(true);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/probate/service/DocumentValidation.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/DocumentValidation.java
@@ -89,7 +89,7 @@ public class DocumentValidation {
      * @return An empty Optional if document is of expected type, or a descriptive error String if not.
      */
     public Optional<String> validateUploadedDocumentIsType(
-            final long caseId,
+            final Long caseId,
             final DocumentLink uploadedDocumentLink,
             final MediaType expectedType) {
 

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -52,4 +52,8 @@ public class FeatureToggleService {
     public boolean enableNewAliasTransformation() {
         return this.isFeatureToggleOn("probate-enable-new-alias-transformation", false);
     }
+
+    public boolean enableAmendLegalStatementFiletypeCheck() {
+        return this.isFeatureToggleOn("enable-amend-legal-statement-filetype-check", false);
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4647](https://tools.hmcts.net/jira/browse/DTSPB-4647)

### Change description ###
Adds a feature flag which permits disabling the filetype verification. This is needed as currently the metadata lookup fails in production and AAT.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
