### PR TITLE
DTSPB-4470 remove flag and old behaviour for old deceased alias name handling

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -45,11 +45,6 @@ public class FeatureToggleService {
     public boolean isFeatureToggleOn(String featureToggleCode, boolean defaultValue) {
         return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
     }
-
-    public boolean enableNewAliasTransformation() {
-        return this.isFeatureToggleOn("probate-enable-new-alias-transformation", false);
-    }
-
     public boolean enableAmendLegalStatementFiletypeCheck() {
         return this.isFeatureToggleOn("enable-amend-legal-statement-filetype-check", false);
     }

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -45,6 +45,7 @@ public class FeatureToggleService {
     public boolean isFeatureToggleOn(String featureToggleCode, boolean defaultValue) {
         return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
     }
+
     public boolean enableAmendLegalStatementFiletypeCheck() {
         return this.isFeatureToggleOn("enable-amend-legal-statement-filetype-check", false);
     }

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -36,7 +36,6 @@ import uk.gov.hmcts.probate.security.SecurityDTO;
 import uk.gov.hmcts.probate.security.SecurityUtils;
 import uk.gov.hmcts.probate.service.ExceptedEstateDateOfDeathChecker;
 import uk.gov.hmcts.probate.service.ExecutorsApplyingNotificationService;
-import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.ccd.AuditEventService;
 import uk.gov.hmcts.probate.service.organisations.OrganisationsRetrievalService;
 import uk.gov.hmcts.probate.service.solicitorexecutor.FormattingService;
@@ -155,7 +154,6 @@ public class CallbackResponseTransformer {
     private final IhtEstateDefaulter ihtEstateDefaulter;
     private final Iht400421Defaulter iht400421Defaulter;
     private final ExceptedEstateDateOfDeathChecker exceptedEstateDateOfDeathChecker;
-    private final FeatureToggleService featureToggleService;
     private final AuditEventService auditEventService;
     private final SecurityUtils securityUtils;
 
@@ -1420,12 +1418,10 @@ public class CallbackResponseTransformer {
             .executorsNamed(caseData.getExecutorsNamed())
             .ttl(caseData.getTtl());
 
-        if (featureToggleService.enableNewAliasTransformation()) {
-            handleDeceasedAliases(
-                    builder,
-                    caseData,
-                    caseDetails.getId());
-        }
+        handleDeceasedAliases(
+                builder,
+                caseData,
+                caseDetails.getId());
 
         if (transform) {
             updateCaseBuilderForTransformCase(caseData, builder);

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -1425,12 +1425,6 @@ public class CallbackResponseTransformer {
                     builder,
                     caseData,
                     caseDetails.getId());
-        } else {
-            builder.solsDeceasedAliasNamesList(getSolsDeceasedAliasNamesList(caseData));
-
-            builder.deceasedAnyOtherNameOnWill(caseData.getDeceasedAnyOtherNameOnWill());
-            builder.deceasedAliasFirstNameOnWill(caseData.getDeceasedAliasFirstNameOnWill());
-            builder.deceasedAliasLastNameOnWill(caseData.getDeceasedAliasLastNameOnWill());
         }
 
         if (transform) {

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -4572,10 +4572,16 @@ class CallbackResponseTransformerTest {
         CallbackResponse callbackResponse = underTest.transformCase(callbackRequestMock, CASEWORKER_USERINFO);
 
         assertApplicationType(callbackResponse, ApplicationType.PERSONAL);
-        assertEquals("John Doe",
+        assertEquals(SOLS_ALIAS_NAME,
                 callbackResponse.getData()
                         .getSolsDeceasedAliasNamesList()
                         .get(0)
+                        .getValue()
+                        .getSolsAliasname());
+        assertEquals("John Doe",
+                callbackResponse.getData()
+                        .getSolsDeceasedAliasNamesList()
+                        .get(1)
                         .getValue()
                         .getSolsAliasname());
         assertEquals(2, callbackResponse.getData().getSolsDeceasedAliasNamesList().size());
@@ -4940,9 +4946,9 @@ class CallbackResponseTransformerTest {
             underTest.getResponseCaseData(caseDetailsMock, eventId, Optional.empty(), transform);
         }
 
-        verify(builderSpy).deceasedAnyOtherNameOnWill(NO);
-        verify(builderSpy).deceasedAliasFirstNameOnWill(WILL_ALIAS_FN);
-        verify(builderSpy).deceasedAliasLastNameOnWill(WILL_ALIAS_LN);
+        verify(builderSpy, never()).deceasedAnyOtherNameOnWill(any());
+        verify(builderSpy, never()).deceasedAliasFirstNameOnWill(any());
+        verify(builderSpy, never()).deceasedAliasLastNameOnWill(any());
 
         verify(builderSpy, never()).deceasedAliasNamesList(any());
 
@@ -4969,7 +4975,6 @@ class CallbackResponseTransformerTest {
         final boolean transform = false;
 
         final Set<CollectionMember<AliasName>> expAliases = Set.of(
-                WILL_ALIAS_NAME_CM,
                 DEC_ALIAS_NAME_CM,
                 SOL_DEC_ALIAS_NAME_CM);
         final AliasMatcher expAliasMatcher = new AliasMatcher(expAliases);
@@ -4980,9 +4985,9 @@ class CallbackResponseTransformerTest {
             underTest.getResponseCaseData(caseDetailsMock, eventId, Optional.empty(), transform);
         }
 
-        verify(builderSpy).deceasedAnyOtherNameOnWill(YES);
-        verify(builderSpy).deceasedAliasFirstNameOnWill(WILL_ALIAS_FN);
-        verify(builderSpy).deceasedAliasLastNameOnWill(WILL_ALIAS_LN);
+        verify(builderSpy, never()).deceasedAnyOtherNameOnWill(any());
+        verify(builderSpy, never()).deceasedAliasFirstNameOnWill(any());
+        verify(builderSpy, never()).deceasedAliasLastNameOnWill(any());
 
         verify(builderSpy, never()).deceasedAliasNamesList(any());
 

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -58,7 +58,6 @@ import uk.gov.hmcts.probate.security.SecurityDTO;
 import uk.gov.hmcts.probate.security.SecurityUtils;
 import uk.gov.hmcts.probate.service.ExceptedEstateDateOfDeathChecker;
 import uk.gov.hmcts.probate.service.ExecutorsApplyingNotificationService;
-import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.StateChangeService;
 import uk.gov.hmcts.probate.service.ccd.AuditEventService;
 import uk.gov.hmcts.probate.service.organisations.OrganisationsRetrievalService;
@@ -586,8 +585,6 @@ class CallbackResponseTransformerTest {
     private SecurityDTO securityDTO;
     @Mock
     private AuditEventService auditEventService;
-    @Mock
-    private FeatureToggleService featureToggleService;
 
     @BeforeEach
     public void setup() {
@@ -5016,8 +5013,6 @@ class CallbackResponseTransformerTest {
                 DEC_ALIAS_NAME_CM,
                 SOL_DEC_ALIAS_NAME_CM);
         final AliasMatcher expAliasMatcher = new AliasMatcher(expAliases);
-
-        when(featureToggleService.enableNewAliasTransformation()).thenReturn(true);
 
         try (MockedStatic<ResponseCaseData> respCaseData = mockStatic(ResponseCaseData.class)) {
             respCaseData.when(ResponseCaseData::builder).thenReturn(builderSpy);


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4470](https://tools.hmcts.net/jira/browse/DTSPB-4470).


### Change description ###
Removes a no-longer-neededd feature flag (and the old behaviour associated with it), as well as updating tests which relied on the old behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
