### PR TITLE
DTSPB-5009 filter cases where 'evidenceHandled' is not No.

### DIFF
--- a/src/main/resources/templates/elasticsearch/caseMatching/first_stop_reminder_query.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/first_stop_reminder_query.json
@@ -19,13 +19,22 @@
           }
         }
       ],
-      "must_not": {
-        "terms": {
-          "data.caseType.keyword": [
-            "edgeCase"
-          ]
+      "must_not": [
+        {
+          "terms": {
+            "data.caseType.keyword": [
+              "edgeCase"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "data.evidenceHandled": [
+              "No"
+            ]
+          }
         }
-      }
+      ]
     }
   },
   "size": %s,

--- a/src/main/resources/templates/elasticsearch/caseMatching/second_stop_reminder_query.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/second_stop_reminder_query.json
@@ -19,13 +19,22 @@
           }
         }
       ],
-      "must_not": {
-        "terms": {
-          "data.caseType.keyword": [
-            "edgeCase"
-          ]
+      "must_not": [
+        {
+          "terms": {
+            "data.caseType.keyword": [
+              "edgeCase"
+            ]
+          }
+        },
+        {
+          "terms": {
+            "data.evidenceHandled": [
+              "No"
+            ]
+          }
         }
-      }
+      ]
     }
   },
   "size": %s,


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-5009](https://tools.hmcts.net/jira/browse/DTSPB-5009)

### Change description ###
Adds a negative filter for `evidenceHandled` == `No` - this means we include cases where 'evidenceHandled' is not set as well as `Yes` (there are currently 14 cases in that state vs over 10k with a `Yes` value so this is an edge case, but better to be explicit i think)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
