### PR TITLE
suppress CVE-2020-29582

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,4 +24,11 @@
         -->
         <cve>CVE-2025-15104</cve>
     </suppress>
+    <suppress until = "2026-07-13">
+        <notes><![CDATA[
+   file name: kotlin-stdlib-1.9.25.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -28,7 +28,6 @@
         <notes><![CDATA[
    file name: kotlin-stdlib-1.9.25.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
         <cve>CVE-2020-29582</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
suppress CVE-2020-29582, as there is currently no fixed version available for ccd-case-document-am-client and core-case-data-store-client


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
