### PR TITLE
DTSPB-5206 use json lib not strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,7 @@ dependencies {
   testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: versions.fortifyClientVersion, classifier: 'all'
   testImplementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jacksonDatabind
   testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.23.0'
+  testImplementation group: 'com.spotify', name: 'hamcrest-optional', version: '1.3.2'
 
   testSmokeImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
   testSmokeImplementation sourceSets.main.runtimeClasspath

--- a/src/main/java/uk/gov/hmcts/probate/exception/JsonObjectUtilsException.java
+++ b/src/main/java/uk/gov/hmcts/probate/exception/JsonObjectUtilsException.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.probate.exception;
+
+import lombok.EqualsAndHashCode;
+
+import java.util.Objects;
+
+@EqualsAndHashCode(callSuper = true)
+public class JsonObjectUtilsException extends BusinessValidationException {
+    final Cause errorCause;
+
+    public JsonObjectUtilsException(
+            final String message,
+            final Cause errorCause) {
+        super("An internal error has occurred when trying to query for matching cases", message);
+        this.errorCause = Objects.requireNonNull(errorCause);
+    }
+
+    public Cause getErrorCause() {
+        return errorCause;
+    }
+
+    public enum Cause {
+        WRONG_TYPE,
+        NO_SUBKEY,
+        MISMATCHED_SUBKEY,
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/query/CaseMatchingJson.java
+++ b/src/main/java/uk/gov/hmcts/probate/query/CaseMatchingJson.java
@@ -1,0 +1,162 @@
+package uk.gov.hmcts.probate.query;
+
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.springframework.lang.CheckReturnValue;
+import uk.gov.hmcts.probate.service.JsonObjectUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Slf4j
+public class CaseMatchingJson {
+    private final JsonObjectUtils jsonObjectUtils;
+    private final AtomicReference<JSONObject> jsonObject;
+
+    public CaseMatchingJson(
+            final JsonObjectUtils jsonObjectUtils,
+            final JSONObject queryJson) {
+        this.jsonObjectUtils = Objects.requireNonNull(jsonObjectUtils);
+        Objects.requireNonNull(queryJson);
+        jsonObject = new AtomicReference<>(queryJson);
+    }
+
+    private void updateForenames(
+            final JSONObject query,
+            final String deceasedForenames,
+            final JSONPointer pointer) {
+        final JSONObject forenameQuery = jsonObjectUtils.findObjectInQuery(
+                query,
+                pointer,
+                "query",
+                ":deceasedForenames");
+        forenameQuery.put("query", deceasedForenames);
+    }
+
+    private void updateSurname(
+            final JSONObject query,
+            final String deceasedSurname,
+            final JSONPointer pointer) {
+        final JSONObject surnameQuery = jsonObjectUtils.findObjectInQuery(
+                query,
+                pointer,
+                "query",
+                ":deceasedSurname");
+        surnameQuery.put("query", deceasedSurname);
+    }
+
+    private void updateFullName(
+            final JSONObject query,
+            final String deceasedFullName,
+            final JSONPointer pointer) {
+        final JSONObject fullNameQuery = jsonObjectUtils.findObjectInQuery(
+                query,
+                pointer,
+                "query",
+                ":deceasedFullName");
+        fullNameQuery.put("query", deceasedFullName);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withDeceasedForenames(final String deceasedForenames) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+
+        updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/0/bool/must/0/multi_match"));
+        updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/1/bool/must/0/multi_match"));
+        updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/2/bool/must/0/multi_match"));
+        updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/3/bool/must/0/multi_match"));
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withDeceasedSurname(final String deceasedSurname) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+
+        updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/0/bool/must/1/multi_match"));
+        updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/1/bool/must/1/multi_match"));
+        updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/2/bool/must/1/multi_match"));
+        updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/3/bool/must/1/multi_match"));
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withDeceasedFullname(final String deceasedFullname) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/4/multi_match"));
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/5/multi_match"));
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/6/multi_match"));
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/7/multi_match"));
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/8/multi_match"));
+        updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/9/multi_match"));
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withDateOfBirth(final Optional<CaseMatchingJson> dateOfBirthQuery) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+        if (dateOfBirthQuery.isEmpty()) {
+            return new CaseMatchingJson(jsonObjectUtils, query);
+        }
+
+        final JSONObject dobQuery = dateOfBirthQuery.get().stealJson().orElseThrow();
+        final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
+                query,
+                new JSONPointer("/query/bool/filter/bool/must"));
+        mustFilter.put(dobQuery);
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withDateOfDeath(final Optional<CaseMatchingJson> dateOfDeathQuery) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+        if (dateOfDeathQuery.isEmpty()) {
+            return new CaseMatchingJson(jsonObjectUtils, query);
+        }
+
+        final JSONObject dodQuery = dateOfDeathQuery.get().stealJson().orElseThrow();
+        final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
+                query,
+                new JSONPointer("/query/bool/filter/bool/must")
+        );
+        mustFilter.put(dodQuery);
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public CaseMatchingJson withAliases(final List<CaseMatchingJson> aliasesToNameSubqueries) {
+        final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+        if (aliasesToNameSubqueries.isEmpty()) {
+            return new CaseMatchingJson(jsonObjectUtils, query);
+        }
+
+        final JSONArray shouldFilter = jsonObjectUtils.findArrayInQuery(
+                query,
+                new JSONPointer("/query/bool/should"));
+        for (final CaseMatchingJson caseMatchingJson : aliasesToNameSubqueries) {
+            final JSONObject subQuery = caseMatchingJson.stealJson().orElseThrow();
+            shouldFilter.put(subQuery);
+        }
+
+        return new CaseMatchingJson(jsonObjectUtils, query);
+    }
+
+    @CheckReturnValue
+    public Optional<JSONObject> stealJson() {
+        final JSONObject queryJson = jsonObject.getAndSet(null);
+        if (queryJson == null) {
+            log.warn("Attempting to reuse a CaseMatchingJson where the internal state has been cleared");
+            return Optional.empty();
+        }
+        return Optional.of(queryJson);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/query/CaseMatchingJson.java
+++ b/src/main/java/uk/gov/hmcts/probate/query/CaseMatchingJson.java
@@ -17,6 +17,8 @@ public class CaseMatchingJson {
     private final JsonObjectUtils jsonObjectUtils;
     private final AtomicReference<JSONObject> jsonObject;
 
+    private static final String QUERY = "query";
+
     public CaseMatchingJson(
             final JsonObjectUtils jsonObjectUtils,
             final JSONObject queryJson) {
@@ -32,9 +34,9 @@ public class CaseMatchingJson {
         final JSONObject forenameQuery = jsonObjectUtils.findObjectInQuery(
                 query,
                 pointer,
-                "query",
+                QUERY,
                 ":deceasedForenames");
-        forenameQuery.put("query", deceasedForenames);
+        forenameQuery.put(QUERY, deceasedForenames);
     }
 
     private void updateSurname(
@@ -44,9 +46,9 @@ public class CaseMatchingJson {
         final JSONObject surnameQuery = jsonObjectUtils.findObjectInQuery(
                 query,
                 pointer,
-                "query",
+                QUERY,
                 ":deceasedSurname");
-        surnameQuery.put("query", deceasedSurname);
+        surnameQuery.put(QUERY, deceasedSurname);
     }
 
     private void updateFullName(
@@ -56,9 +58,9 @@ public class CaseMatchingJson {
         final JSONObject fullNameQuery = jsonObjectUtils.findObjectInQuery(
                 query,
                 pointer,
-                "query",
+                QUERY,
                 ":deceasedFullName");
-        fullNameQuery.put("query", deceasedFullName);
+        fullNameQuery.put(QUERY, deceasedFullName);
     }
 
     @CheckReturnValue

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -1,0 +1,173 @@
+package uk.gov.hmcts.probate.service;
+
+import com.jayway.jsonpath.JsonPath;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Slf4j
+public class CaseMatchingJsonService {
+
+    private static final String TEMPLATE_DIRECTORY = "templates/elasticsearch/caseMatching/";
+    private static final String ES_BASE = "templates/elasticsearch/caseMatching/json/matching_base.json";
+
+    private final FileSystemResourceService fileSystemResourceService;
+
+    public CaseMatchingJsonService(
+            final FileSystemResourceService fileSystemResourceService) {
+        this.fileSystemResourceService = fileSystemResourceService;
+    }
+
+    public CaseMatchingJson getBaseQuery() {
+        final String baseQueryString = fileSystemResourceService.getFileFromResourceAsString(ES_BASE);
+        return new CaseMatchingJson(baseQueryString);
+    }
+
+    public Optional<CaseMatchingJson> getDateOfBirthSubquery(final LocalDate dateOfBirth) {
+        throw new NotImplementedException();
+    }
+
+    public Optional<CaseMatchingJson> getDateOfDeathSubquery(final LocalDate dateOfDeath) {
+        throw new NotImplementedException();
+    }
+
+    public List<CaseMatchingJson> getAliasesToNameSubqueries(final List<String> aliases) {
+        throw new NotImplementedException();
+    }
+
+    public List<CaseMatchingJson> getAliasesToAliasesSubqueries(final List<String> aliases) {
+        throw new NotImplementedException();
+    }
+
+    public List<CaseMatchingJson> getAliasesToAliasesNameListSubqueries(final List<String> aliases) {
+        throw new NotImplementedException();
+    }
+
+    public static class CaseMatchingJson {
+        private final AtomicReference<JSONObject> jsonObject;
+
+        private CaseMatchingJson(final String baseQuery) {
+            final JSONObject baseQueryJson = new JSONObject(baseQuery);
+            jsonObject = new AtomicReference<>(baseQueryJson);
+        }
+
+        private CaseMatchingJson(final JSONObject queryJson) {
+            Objects.requireNonNull(queryJson);
+            jsonObject = new AtomicReference<>(queryJson);
+        }
+
+        private JSONObject getJsonObject(
+                final JSONObject query,
+                final JSONPointer pointer) {
+            final Object fromPointer = query.query(pointer);
+            if (!(fromPointer instanceof JSONObject)) {
+                throw new IllegalStateException("Expected JSON object but got " + fromPointer);
+            }
+            final JSONObject queryObject = (JSONObject) fromPointer;
+            if (!queryObject.has("query")) {
+                throw new IllegalStateException("Expected JSON object with \"query\" key but got " + queryObject);
+            }
+            return queryObject;
+        }
+
+        private void updateForenames(
+                final JSONObject query,
+                final String deceasedForenames,
+                final JSONPointer pointer) {
+            final JSONObject forenameQuery = getJsonObject(query, pointer);
+            if (!forenameQuery.getString("query").equals(":deceasedForenames")) {
+                throw new IllegalStateException(
+                        "Expected JSON object with \"query\" key with value \":deceasedForenames\" but got "
+                                + forenameQuery);
+            }
+            forenameQuery.put("query", deceasedForenames);
+        }
+
+        private void updateSurname(
+                final JSONObject query,
+                final String deceasedSurname,
+                final JSONPointer pointer) {
+            final JSONObject surnameQuery = getJsonObject(query, pointer);
+            if (!surnameQuery.getString("query").equals(":deceasedForename")) {
+                throw new IllegalStateException(
+                        "Expected JSON object with \"query\" key with value \":deceasedSurname\" but got "
+                                + surnameQuery);
+            }
+            surnameQuery.put("query", deceasedSurname);
+        }
+
+        private void updateFullName(
+                final JSONObject query,
+                final String deceasedFullName,
+                final JSONPointer pointer) {
+            final JSONObject fullNameQuery = getJsonObject(query, pointer);
+            if (!fullNameQuery.getString("query").equals(":deceasedFullName")) {
+                throw new IllegalStateException(
+                        "Expected JSON object with \"query\" key with value \":deceasedFullName\" but got "
+                                + fullNameQuery);
+            }
+            fullNameQuery.put("query", deceasedFullName);
+        }
+
+        public CaseMatchingJson withDeceasedForenames(final String deceasedForenames) {
+            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+
+            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/0/bool/must/0/multi_match"));
+            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/1/bool/must/0/multi_match"));
+            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/3/bool/must/0/multi_match"));
+            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/4/bool/must/0/multi_match"));
+
+            return new CaseMatchingJson(query);
+        }
+
+        public CaseMatchingJson withDeceasedSurname(final String deceasedSurname) {
+            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+
+            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/0/bool/must/1/multi_match"));
+            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/1/bool/must/1/multi_match"));
+            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/3/bool/must/1/multi_match"));
+            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/4/bool/must/1/multi_match"));
+
+            return new CaseMatchingJson(query);
+        }
+
+        public CaseMatchingJson withDeceasedFullname(final String deceasedFullname) {
+            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/5/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/6/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/8/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/9/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/11/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/12/multi_match"));
+
+            return new CaseMatchingJson(query);
+        }
+
+        public CaseMatchingJson withDateOfBirth(final Optional<CaseMatchingJson> dateOfBirthQuery) {
+            throw new NotImplementedException();
+        }
+
+        public CaseMatchingJson withDateOfDeath(final Optional<CaseMatchingJson> dateOfDeathQuery) {
+            throw new NotImplementedException();
+        }
+
+        public Optional<JSONObject> stealJson() {
+            final JSONObject queryJson = jsonObject.getAndSet(null);
+            if (queryJson == null) {
+                log.warn("Attempting to reuse a CaseMatchingJson where the internal state has been cleared");
+                return Optional.empty();
+            }
+            return Optional.of(queryJson);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.probate.service;
 
-import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.json.JSONArray;
@@ -8,6 +7,7 @@ import org.json.JSONObject;
 import org.json.JSONPointer;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -16,78 +16,115 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class CaseMatchingJsonService {
 
-    private static final String TEMPLATE_DIRECTORY = "templates/elasticsearch/caseMatching/";
     private static final String ES_BASE = "templates/elasticsearch/caseMatching/json/matching_base.json";
+    private static final String DOB_BASE = "templates/elasticsearch/caseMatching/json/deceased_dob_sub_query.json";
+    private static final String DOD_BASE = "templates/elasticsearch/caseMatching/json/deceased_dod_sub_query.json";
 
     private final FileSystemResourceService fileSystemResourceService;
+    private final JsonObjectUtils jsonObjectUtils;
 
     public CaseMatchingJsonService(
-            final FileSystemResourceService fileSystemResourceService) {
+            final FileSystemResourceService fileSystemResourceService,
+            final JsonObjectUtils jsonObjectUtils) {
         this.fileSystemResourceService = fileSystemResourceService;
+        this.jsonObjectUtils = jsonObjectUtils;
     }
 
     public CaseMatchingJson getBaseQuery() {
         final String baseQueryString = fileSystemResourceService.getFileFromResourceAsString(ES_BASE);
-        return new CaseMatchingJson(baseQueryString);
+        return new CaseMatchingJson(jsonObjectUtils, baseQueryString);
     }
 
     public Optional<CaseMatchingJson> getDateOfBirthSubquery(final LocalDate dateOfBirth) {
-        throw new NotImplementedException();
+        if (dateOfBirth == null) {
+            return Optional.empty();
+        }
+        final String dobFormatted = dateOfBirth.format(DateTimeFormatter.ISO_DATE);
+
+        final String dobQueryString = fileSystemResourceService.getFileFromResourceAsString(DOB_BASE);
+        final JSONObject dobQuery = new JSONObject(dobQueryString);
+
+        final JSONObject valueObject = jsonObjectUtils.findObjectInQuery(
+                dobQuery,
+                new JSONPointer("/bool/should/0/term/data.deceasedDateOfBirth"),
+                "value",
+                ":deceasedDateOfBirth");
+        valueObject.put("value", dobFormatted);
+
+        return Optional.of(new CaseMatchingJson(jsonObjectUtils, dobQuery));
     }
 
     public Optional<CaseMatchingJson> getDateOfDeathSubquery(final LocalDate dateOfDeath) {
-        throw new NotImplementedException();
+        if (dateOfDeath == null) {
+            return Optional.empty();
+        }
+        final String dodFormatted = dateOfDeath.format(DateTimeFormatter.ISO_DATE);
+
+        final String dobQueryString = fileSystemResourceService.getFileFromResourceAsString(DOD_BASE);
+        final JSONObject dodQuery = new JSONObject(dobQueryString);
+
+        final JSONObject dodRange = jsonObjectUtils.findObjectInQuery(
+                dodQuery,
+                new JSONPointer("/bool/should/0/bool/should/1/bool/should/1/range/data.deceasedDateOfDeath"),
+                "gte",
+                ":deceasedDateOfDeath||-3d");
+        // we could make this configurable (not in scope)
+        dodRange.put("gte", dodFormatted + "||-3d");
+        dodRange.put("lte", dodFormatted + "||+3d");
+
+        final JSONObject dodLte = jsonObjectUtils.findObjectInQuery(
+                dodQuery,
+                new JSONPointer("/bool/should/1/bool/must/2/bool/must/range/data.deceasedDateOfDeath"),
+                "lte",
+                ":deceasedDateOfDeath");
+        dodLte.put("lte", dodFormatted);
+
+        final JSONObject dodGte = jsonObjectUtils.findObjectInQuery(
+                dodQuery,
+                new JSONPointer("/bool/should/1/bool/must/3/bool/must/range/data.deceasedDateOfDeath2"),
+                "gte",
+                ":deceasedDateOfDeath");
+        dodGte.put("gte", dodFormatted);
+
+        return Optional.of(new CaseMatchingJson(jsonObjectUtils, dodQuery));
     }
 
-    public List<CaseMatchingJson> getAliasesToNameSubqueries(final List<String> aliases) {
+    public List<CaseMatchingJson> getAliasesSubqueries(final List<String> aliases) {
         throw new NotImplementedException();
-    }
-
-    public List<CaseMatchingJson> getAliasesToAliasesSubqueries(final List<String> aliases) {
-        throw new NotImplementedException();
-    }
-
-    public List<CaseMatchingJson> getAliasesToAliasesNameListSubqueries(final List<String> aliases) {
-        throw new NotImplementedException();
+//        final String baseQueryString = fileSystemResourceService.getFileFromResourceAsString(ES_BASE);
+//        return new CaseMatchingJson(jsonObjectUtils, baseQueryString);
     }
 
     public static class CaseMatchingJson {
+        private final JsonObjectUtils jsonObjectUtils;
         private final AtomicReference<JSONObject> jsonObject;
 
-        private CaseMatchingJson(final String baseQuery) {
+        private CaseMatchingJson(
+                final JsonObjectUtils jsonObjectUtils,
+                final String baseQuery) {
+            this.jsonObjectUtils = Objects.requireNonNull(jsonObjectUtils);
+
             final JSONObject baseQueryJson = new JSONObject(baseQuery);
             jsonObject = new AtomicReference<>(baseQueryJson);
         }
 
-        private CaseMatchingJson(final JSONObject queryJson) {
+        private CaseMatchingJson(
+                final JsonObjectUtils jsonObjectUtils,
+                final JSONObject queryJson) {
+            this.jsonObjectUtils = Objects.requireNonNull(jsonObjectUtils);
             Objects.requireNonNull(queryJson);
             jsonObject = new AtomicReference<>(queryJson);
-        }
-
-        private JSONObject getJsonObject(
-                final JSONObject query,
-                final JSONPointer pointer) {
-            final Object fromPointer = query.query(pointer);
-            if (!(fromPointer instanceof JSONObject)) {
-                throw new IllegalStateException("Expected JSON object but got " + fromPointer);
-            }
-            final JSONObject queryObject = (JSONObject) fromPointer;
-            if (!queryObject.has("query")) {
-                throw new IllegalStateException("Expected JSON object with \"query\" key but got " + queryObject);
-            }
-            return queryObject;
         }
 
         private void updateForenames(
                 final JSONObject query,
                 final String deceasedForenames,
                 final JSONPointer pointer) {
-            final JSONObject forenameQuery = getJsonObject(query, pointer);
-            if (!forenameQuery.getString("query").equals(":deceasedForenames")) {
-                throw new IllegalStateException(
-                        "Expected JSON object with \"query\" key with value \":deceasedForenames\" but got "
-                                + forenameQuery);
-            }
+            final JSONObject forenameQuery = jsonObjectUtils.findObjectInQuery(
+                    query,
+                    pointer,
+                    "query",
+                    ":deceasedForenames");
             forenameQuery.put("query", deceasedForenames);
         }
 
@@ -95,12 +132,11 @@ public class CaseMatchingJsonService {
                 final JSONObject query,
                 final String deceasedSurname,
                 final JSONPointer pointer) {
-            final JSONObject surnameQuery = getJsonObject(query, pointer);
-            if (!surnameQuery.getString("query").equals(":deceasedForename")) {
-                throw new IllegalStateException(
-                        "Expected JSON object with \"query\" key with value \":deceasedSurname\" but got "
-                                + surnameQuery);
-            }
+            final JSONObject surnameQuery = jsonObjectUtils.findObjectInQuery(
+                    query,
+                    pointer,
+                    "query",
+                    ":deceasedSurname");
             surnameQuery.put("query", deceasedSurname);
         }
 
@@ -108,56 +144,95 @@ public class CaseMatchingJsonService {
                 final JSONObject query,
                 final String deceasedFullName,
                 final JSONPointer pointer) {
-            final JSONObject fullNameQuery = getJsonObject(query, pointer);
-            if (!fullNameQuery.getString("query").equals(":deceasedFullName")) {
-                throw new IllegalStateException(
-                        "Expected JSON object with \"query\" key with value \":deceasedFullName\" but got "
-                                + fullNameQuery);
-            }
+            final JSONObject fullNameQuery = jsonObjectUtils.findObjectInQuery(
+                    query,
+                    pointer,
+                    "query",
+                    ":deceasedFullName");
             fullNameQuery.put("query", deceasedFullName);
         }
 
         public CaseMatchingJson withDeceasedForenames(final String deceasedForenames) {
-            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
 
             updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/0/bool/must/0/multi_match"));
             updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/1/bool/must/0/multi_match"));
+            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/2/bool/must/0/multi_match"));
             updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/3/bool/must/0/multi_match"));
-            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/4/bool/must/0/multi_match"));
 
-            return new CaseMatchingJson(query);
+            return new CaseMatchingJson(jsonObjectUtils, query);
         }
 
         public CaseMatchingJson withDeceasedSurname(final String deceasedSurname) {
-            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
 
             updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/0/bool/must/1/multi_match"));
             updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/1/bool/must/1/multi_match"));
+            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/2/bool/must/1/multi_match"));
             updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/3/bool/must/1/multi_match"));
-            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/4/bool/must/1/multi_match"));
 
-            return new CaseMatchingJson(query);
+            return new CaseMatchingJson(jsonObjectUtils, query);
         }
 
         public CaseMatchingJson withDeceasedFullname(final String deceasedFullname) {
-            final JSONObject query = Objects.requireNonNull(this.jsonObject.getAndSet(null));
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
 
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/4/multi_match"));
             updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/5/multi_match"));
             updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/6/multi_match"));
+            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/7/multi_match"));
             updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/8/multi_match"));
             updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/9/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/11/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/12/multi_match"));
 
-            return new CaseMatchingJson(query);
+            return new CaseMatchingJson(jsonObjectUtils, query);
         }
 
         public CaseMatchingJson withDateOfBirth(final Optional<CaseMatchingJson> dateOfBirthQuery) {
-            throw new NotImplementedException();
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+            if (dateOfBirthQuery.isEmpty()) {
+                return new CaseMatchingJson(jsonObjectUtils, query);
+            }
+
+            final JSONObject dobQuery = dateOfBirthQuery.get().stealJson().orElseThrow();
+            final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
+                    query,
+                    new JSONPointer("/query/bool/filter/bool/must"));
+            mustFilter.put(dobQuery);
+
+            return new CaseMatchingJson(jsonObjectUtils, query);
         }
 
         public CaseMatchingJson withDateOfDeath(final Optional<CaseMatchingJson> dateOfDeathQuery) {
-            throw new NotImplementedException();
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+            if (dateOfDeathQuery.isEmpty()) {
+                return new CaseMatchingJson(jsonObjectUtils, query);
+            }
+
+            final JSONObject dodQuery = dateOfDeathQuery.get().stealJson().orElseThrow();
+            final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
+                    query,
+                    new JSONPointer("/query/bool/filter/bool/must")
+            );
+            mustFilter.put(dodQuery);
+
+            return new CaseMatchingJson(jsonObjectUtils, query);
+        }
+
+        public CaseMatchingJson withAliases(final List<CaseMatchingJson> aliasesToNameSubqueries) {
+            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
+            if (aliasesToNameSubqueries.isEmpty()) {
+                return new CaseMatchingJson(jsonObjectUtils, query);
+            }
+
+            final JSONArray shouldFilter = jsonObjectUtils.findArrayInQuery(
+                    query,
+                    new JSONPointer("/query/bool/should"));
+            for (final CaseMatchingJson caseMatchingJson : aliasesToNameSubqueries) {
+                final JSONObject subQuery = caseMatchingJson.stealJson().orElseThrow();
+                shouldFilter.put(subQuery);
+            }
+
+            return new CaseMatchingJson(jsonObjectUtils, query);
         }
 
         public Optional<JSONObject> stealJson() {
@@ -170,4 +245,38 @@ public class CaseMatchingJsonService {
         }
     }
 
+    static class JsonObjectUtils {
+        private JSONObject findObjectInQuery(
+                final JSONObject queryObject,
+                final JSONPointer pointer,
+                final String expectKey,
+                final String expectValue) {
+            final Object fromPointer = queryObject.query(pointer);
+            if (!(fromPointer instanceof JSONObject)) {
+                throw new IllegalStateException("Expected JSON object but got " + fromPointer);
+            }
+            final JSONObject subObject = (JSONObject) fromPointer;
+            if (!subObject.has(expectKey)) {
+                throw new IllegalStateException(
+                        "Expected JSON object with \"" + expectKey + "\" key but got " + subObject);
+            }
+            if (!subObject.get(expectKey).equals(expectValue)) {
+                throw new IllegalStateException(
+                        "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue + "\" but got "
+                                + subObject);
+            }
+            return subObject;
+        }
+
+        private JSONArray findArrayInQuery(
+                final JSONObject queryObject,
+                final JSONPointer pointer) {
+            final Object fromPointer = queryObject.query(pointer);
+            if (!(fromPointer instanceof JSONArray)) {
+                throw new IllegalStateException("Expected JSON array but got " + fromPointer);
+            }
+            final JSONArray array = (JSONArray) fromPointer;
+            return array;
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -1,18 +1,16 @@
 package uk.gov.hmcts.probate.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONPointer;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.probate.query.CaseMatchingJson;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 @Component
@@ -44,7 +42,8 @@ public class CaseMatchingJsonService {
 
     public CaseMatchingJson getBaseQuery() {
         final String baseQueryString = fileSystemResourceService.getFileFromResourceAsString(ES_BASE);
-        return new CaseMatchingJson(jsonObjectUtils, baseQueryString);
+        final JSONObject baseQuery = new JSONObject(baseQueryString);
+        return new CaseMatchingJson(jsonObjectUtils, baseQuery);
     }
 
     public Optional<CaseMatchingJson> getDateOfBirthSubquery(final LocalDate dateOfBirth) {
@@ -80,7 +79,6 @@ public class CaseMatchingJsonService {
                 new JSONPointer("/bool/should/0/bool/should/1/bool/should/1/range/data.deceasedDateOfDeath"),
                 "gte",
                 ":deceasedDateOfDeath||-3d");
-        // we could make this configurable (not in scope)
         dodRange.put("gte", dodFormatted + "||-3d");
         dodRange.put("lte", dodFormatted + "||+3d");
 
@@ -228,189 +226,4 @@ public class CaseMatchingJsonService {
         return List.copyOf(collected);
     }
 
-    public static class CaseMatchingJson {
-        private final JsonObjectUtils jsonObjectUtils;
-        private final AtomicReference<JSONObject> jsonObject;
-
-        private CaseMatchingJson(
-                final JsonObjectUtils jsonObjectUtils,
-                final String baseQuery) {
-            this.jsonObjectUtils = Objects.requireNonNull(jsonObjectUtils);
-
-            final JSONObject baseQueryJson = new JSONObject(baseQuery);
-            jsonObject = new AtomicReference<>(baseQueryJson);
-        }
-
-        private CaseMatchingJson(
-                final JsonObjectUtils jsonObjectUtils,
-                final JSONObject queryJson) {
-            this.jsonObjectUtils = Objects.requireNonNull(jsonObjectUtils);
-            Objects.requireNonNull(queryJson);
-            jsonObject = new AtomicReference<>(queryJson);
-        }
-
-        private void updateForenames(
-                final JSONObject query,
-                final String deceasedForenames,
-                final JSONPointer pointer) {
-            final JSONObject forenameQuery = jsonObjectUtils.findObjectInQuery(
-                    query,
-                    pointer,
-                    "query",
-                    ":deceasedForenames");
-            forenameQuery.put("query", deceasedForenames);
-        }
-
-        private void updateSurname(
-                final JSONObject query,
-                final String deceasedSurname,
-                final JSONPointer pointer) {
-            final JSONObject surnameQuery = jsonObjectUtils.findObjectInQuery(
-                    query,
-                    pointer,
-                    "query",
-                    ":deceasedSurname");
-            surnameQuery.put("query", deceasedSurname);
-        }
-
-        private void updateFullName(
-                final JSONObject query,
-                final String deceasedFullName,
-                final JSONPointer pointer) {
-            final JSONObject fullNameQuery = jsonObjectUtils.findObjectInQuery(
-                    query,
-                    pointer,
-                    "query",
-                    ":deceasedFullName");
-            fullNameQuery.put("query", deceasedFullName);
-        }
-
-        public CaseMatchingJson withDeceasedForenames(final String deceasedForenames) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-
-            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/0/bool/must/0/multi_match"));
-            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/1/bool/must/0/multi_match"));
-            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/2/bool/must/0/multi_match"));
-            updateForenames(query, deceasedForenames, new JSONPointer("/query/bool/should/3/bool/must/0/multi_match"));
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public CaseMatchingJson withDeceasedSurname(final String deceasedSurname) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-
-            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/0/bool/must/1/multi_match"));
-            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/1/bool/must/1/multi_match"));
-            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/2/bool/must/1/multi_match"));
-            updateSurname(query, deceasedSurname, new JSONPointer("/query/bool/should/3/bool/must/1/multi_match"));
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public CaseMatchingJson withDeceasedFullname(final String deceasedFullname) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/4/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/5/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/6/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/7/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/8/multi_match"));
-            updateFullName(query, deceasedFullname, new JSONPointer("/query/bool/should/9/multi_match"));
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public CaseMatchingJson withDateOfBirth(final Optional<CaseMatchingJson> dateOfBirthQuery) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-            if (dateOfBirthQuery.isEmpty()) {
-                return new CaseMatchingJson(jsonObjectUtils, query);
-            }
-
-            final JSONObject dobQuery = dateOfBirthQuery.get().stealJson().orElseThrow();
-            final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
-                    query,
-                    new JSONPointer("/query/bool/filter/bool/must"));
-            mustFilter.put(dobQuery);
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public CaseMatchingJson withDateOfDeath(final Optional<CaseMatchingJson> dateOfDeathQuery) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-            if (dateOfDeathQuery.isEmpty()) {
-                return new CaseMatchingJson(jsonObjectUtils, query);
-            }
-
-            final JSONObject dodQuery = dateOfDeathQuery.get().stealJson().orElseThrow();
-            final JSONArray mustFilter = jsonObjectUtils.findArrayInQuery(
-                    query,
-                    new JSONPointer("/query/bool/filter/bool/must")
-            );
-            mustFilter.put(dodQuery);
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public CaseMatchingJson withAliases(final List<CaseMatchingJson> aliasesToNameSubqueries) {
-            final JSONObject query = Objects.requireNonNull(jsonObject.getAndSet(null));
-            if (aliasesToNameSubqueries.isEmpty()) {
-                return new CaseMatchingJson(jsonObjectUtils, query);
-            }
-
-            final JSONArray shouldFilter = jsonObjectUtils.findArrayInQuery(
-                    query,
-                    new JSONPointer("/query/bool/should"));
-            for (final CaseMatchingJson caseMatchingJson : aliasesToNameSubqueries) {
-                final JSONObject subQuery = caseMatchingJson.stealJson().orElseThrow();
-                shouldFilter.put(subQuery);
-            }
-
-            return new CaseMatchingJson(jsonObjectUtils, query);
-        }
-
-        public Optional<JSONObject> stealJson() {
-            final JSONObject queryJson = jsonObject.getAndSet(null);
-            if (queryJson == null) {
-                log.warn("Attempting to reuse a CaseMatchingJson where the internal state has been cleared");
-                return Optional.empty();
-            }
-            return Optional.of(queryJson);
-        }
-    }
-
-    @Component
-    static class JsonObjectUtils {
-        private JSONObject findObjectInQuery(
-                final JSONObject queryObject,
-                final JSONPointer pointer,
-                final String expectKey,
-                final String expectValue) {
-            final Object fromPointer = queryObject.query(pointer);
-            if (!(fromPointer instanceof JSONObject)) {
-                throw new IllegalStateException("Expected JSON object but got " + fromPointer);
-            }
-            final JSONObject subObject = (JSONObject) fromPointer;
-            if (!subObject.has(expectKey)) {
-                throw new IllegalStateException(
-                        "Expected JSON object with \"" + expectKey + "\" key but got " + subObject);
-            }
-            if (!subObject.get(expectKey).equals(expectValue)) {
-                throw new IllegalStateException(
-                        "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue
-                        + "\" but got " + subObject);
-            }
-            return subObject;
-        }
-
-        private JSONArray findArrayInQuery(
-                final JSONObject queryObject,
-                final JSONPointer pointer) {
-            final Object fromPointer = queryObject.query(pointer);
-            if (!(fromPointer instanceof JSONArray)) {
-                throw new IllegalStateException("Expected JSON array but got " + fromPointer);
-            }
-            final JSONArray array = (JSONArray) fromPointer;
-            return array;
-        }
-    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -8,6 +8,7 @@ import org.json.JSONPointer;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -17,8 +18,16 @@ import java.util.concurrent.atomic.AtomicReference;
 public class CaseMatchingJsonService {
 
     private static final String ES_BASE = "templates/elasticsearch/caseMatching/json/matching_base.json";
+
     private static final String DOB_BASE = "templates/elasticsearch/caseMatching/json/deceased_dob_sub_query.json";
     private static final String DOD_BASE = "templates/elasticsearch/caseMatching/json/deceased_dod_sub_query.json";
+
+    private static final String ALIAS_NAME_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_sub_query_a.json";
+    private static final String ALIAS_NAME_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_sub_query_b.json";
+    private static final String ALIAS_NAME_ALIAS_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_a.json";
+    private static final String ALIAS_NAME_ALIAS_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_b.json";
+    private static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_a.json";
+    private static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_b.json";
 
     private final FileSystemResourceService fileSystemResourceService;
     private final JsonObjectUtils jsonObjectUtils;
@@ -89,10 +98,131 @@ public class CaseMatchingJsonService {
         return Optional.of(new CaseMatchingJson(jsonObjectUtils, dodQuery));
     }
 
+    CaseMatchingJson getAliasNameASubquery(final String alias) {
+        final String aliasNameAString = fileSystemResourceService.getFileFromResourceAsString(ALIAS_NAME_A_BASE);
+        final JSONObject aliasNameAQuery = new JSONObject(aliasNameAString);
+
+        final JSONObject forenameMatch = jsonObjectUtils.findObjectInQuery(
+                aliasNameAQuery,
+                new JSONPointer("/bool/must/0/multi_match"),
+                "query",
+                ":deceasedAlias");
+        forenameMatch.put("query", alias);
+
+        final JSONObject surnameMatch = jsonObjectUtils.findObjectInQuery(
+                aliasNameAQuery,
+                new JSONPointer("/bool/must/1/multi_match"),
+                "query",
+                ":deceasedAlias");
+        surnameMatch.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameAQuery);
+    }
+
+    CaseMatchingJson getAliasNameBSubquery(final String alias) {
+        final String aliasNameBString = fileSystemResourceService.getFileFromResourceAsString(ALIAS_NAME_B_BASE);
+        final JSONObject aliasNameBQuery = new JSONObject(aliasNameBString);
+
+        final JSONObject forenameMatch = jsonObjectUtils.findObjectInQuery(
+                aliasNameBQuery,
+                new JSONPointer("/bool/must/0/multi_match"),
+                "query",
+                ":deceasedAlias");
+        forenameMatch.put("query", alias);
+
+        final JSONObject surnameMatch = jsonObjectUtils.findObjectInQuery(
+                aliasNameBQuery,
+                new JSONPointer("/bool/must/1/multi_match"),
+                "query",
+                ":deceasedAlias");
+        surnameMatch.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameBQuery);
+    }
+
+    CaseMatchingJson getAliasNameAliasASubquery(final String alias) {
+        final String aliasNameAliasAString = fileSystemResourceService
+                .getFileFromResourceAsString(ALIAS_NAME_ALIAS_A_BASE);
+        final JSONObject aliasNameAliasAQuery = new JSONObject(aliasNameAliasAString);
+
+        final JSONObject match = jsonObjectUtils.findObjectInQuery(
+                aliasNameAliasAQuery,
+                new JSONPointer("/multi_match"),
+                "query",
+                ":deceasedAlias");
+        match.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameAliasAQuery);
+    }
+
+    CaseMatchingJson getAliasNameAliasBSubquery(final String alias) {
+        final String aliasNameAliasBString = fileSystemResourceService
+                .getFileFromResourceAsString(ALIAS_NAME_ALIAS_B_BASE);
+        final JSONObject aliasNameAliasBQuery = new JSONObject(aliasNameAliasBString);
+
+        final JSONObject match = jsonObjectUtils.findObjectInQuery(
+                aliasNameAliasBQuery,
+                new JSONPointer("/multi_match"),
+                "query",
+                ":deceasedAlias");
+        match.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameAliasBQuery);
+    }
+
+    CaseMatchingJson getAliasNameSolsAliasASubquery(final String alias) {
+        final String aliasNameSolsAliasAString = fileSystemResourceService
+                .getFileFromResourceAsString(ALIAS_NAME_SOLS_ALIAS_A_BASE);
+        final JSONObject aliasNameSolsAliasAQuery = new JSONObject(aliasNameSolsAliasAString);
+
+        final JSONObject match = jsonObjectUtils.findObjectInQuery(
+                aliasNameSolsAliasAQuery,
+                new JSONPointer("/multi_match"),
+                "query",
+                ":deceasedAlias");
+        match.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameSolsAliasAQuery);
+    }
+
+    CaseMatchingJson getAliasNameSolsAliasBSubquery(final String alias) {
+        final String aliasNameSolsAliasBString = fileSystemResourceService
+                .getFileFromResourceAsString(ALIAS_NAME_SOLS_ALIAS_B_BASE);
+        final JSONObject aliasNameSolsAliasBQuery = new JSONObject(aliasNameSolsAliasBString);
+
+        final JSONObject match = jsonObjectUtils.findObjectInQuery(
+                aliasNameSolsAliasBQuery,
+                new JSONPointer("/multi_match"),
+                "query",
+                ":deceasedAlias");
+        match.put("query", alias);
+
+        return new CaseMatchingJson(jsonObjectUtils, aliasNameSolsAliasBQuery);
+    }
+
+    List<CaseMatchingJson> getAliasSubquerires(final String alias) {
+        final CaseMatchingJson aliasNameA = getAliasNameASubquery(alias);
+        final CaseMatchingJson aliasNameB = getAliasNameBSubquery(alias);
+        final CaseMatchingJson aliasNameAliasA = getAliasNameAliasASubquery(alias);
+        final CaseMatchingJson aliasNameAliasB = getAliasNameAliasBSubquery(alias);
+        final CaseMatchingJson aliasNameSolsAliasA = getAliasNameSolsAliasASubquery(alias);
+        final CaseMatchingJson aliasNAmeSolsAliasB = getAliasNameSolsAliasBSubquery(alias);
+
+        return List.of(
+                aliasNameA,
+                aliasNameB,
+                aliasNameAliasA,
+                aliasNameAliasB,
+                aliasNameSolsAliasA,
+                aliasNAmeSolsAliasB);
+    }
+
     public List<CaseMatchingJson> getAliasesSubqueries(final List<String> aliases) {
-        throw new NotImplementedException();
-//        final String baseQueryString = fileSystemResourceService.getFileFromResourceAsString(ES_BASE);
-//        return new CaseMatchingJson(jsonObjectUtils, baseQueryString);
+        final List<CaseMatchingJson> collected = new ArrayList<>();
+        for (String alias : aliases) {
+            collected.addAll(getAliasSubquerires(alias));
+        }
+        return List.copyOf(collected);
     }
 
     public static class CaseMatchingJson {
@@ -262,8 +392,8 @@ public class CaseMatchingJsonService {
             }
             if (!subObject.get(expectKey).equals(expectValue)) {
                 throw new IllegalStateException(
-                        "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue + "\" but got "
-                                + subObject);
+                        "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue
+                        + "\" but got " + subObject);
             }
             return subObject;
         }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -17,21 +17,21 @@ import java.util.Optional;
 public class CaseMatchingJsonService {
     private static final String JSON_BASE = "templates/elasticsearch/caseMatching/json/";
 
-    private static final String ES_BASE = JSON_BASE + "matching_base.json";
+    static final String ES_BASE = JSON_BASE + "matching_base.json";
 
-    private static final String DOB_BASE = JSON_BASE + "deceased_dob_sub_query.json";
-    private static final String DOD_BASE = JSON_BASE + "deceased_dod_sub_query.json";
+    static final String DOB_BASE = JSON_BASE + "deceased_dob_sub_query.json";
+    static final String DOD_BASE = JSON_BASE + "deceased_dod_sub_query.json";
 
-    private static final String ALIAS_NAME_A_BASE = JSON_BASE + "aliases_sub_query_a.json";
-    private static final String ALIAS_NAME_B_BASE = JSON_BASE + "aliases_sub_query_b.json";
-    private static final String ALIAS_NAME_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_a.json";
-    private static final String ALIAS_NAME_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_b.json";
-    private static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_sub_query_a.json";
-    private static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_sub_query_b.json";
+    static final String ALIAS_NAME_A_BASE = JSON_BASE + "aliases_sub_query_a.json";
+    static final String ALIAS_NAME_B_BASE = JSON_BASE + "aliases_sub_query_b.json";
+    static final String ALIAS_NAME_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_a.json";
+    static final String ALIAS_NAME_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_b.json";
+    static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_sub_query_a.json";
+    static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_sub_query_b.json";
 
-    private static final String QUERY = "query";
-    private static final String DECEASED_ALIAS = ":deceasedAlias";
-    private static final String MULTI_MATCH = "/multi_match";
+    static final String QUERY = "query";
+    static final String DECEASED_ALIAS = ":deceasedAlias";
+    static final String MULTI_MATCH = "/multi_match";
 
     private final FileSystemResourceService fileSystemResourceService;
     private final JsonObjectUtils jsonObjectUtils;
@@ -204,7 +204,7 @@ public class CaseMatchingJsonService {
         return new CaseMatchingJson(jsonObjectUtils, aliasNameSolsAliasBQuery);
     }
 
-    List<CaseMatchingJson> getAliasSubquerires(final String alias) {
+    List<CaseMatchingJson> getAliasSubqueries(final String alias) {
         final CaseMatchingJson aliasNameA = getAliasNameASubquery(alias);
         final CaseMatchingJson aliasNameB = getAliasNameBSubquery(alias);
         final CaseMatchingJson aliasNameAliasA = getAliasNameAliasASubquery(alias);
@@ -224,7 +224,7 @@ public class CaseMatchingJsonService {
     public List<CaseMatchingJson> getAliasesSubqueries(final List<String> aliases) {
         final List<CaseMatchingJson> collected = new ArrayList<>();
         for (String alias : aliases) {
-            collected.addAll(getAliasSubquerires(alias));
+            collected.addAll(getAliasSubqueries(alias));
         }
         return List.copyOf(collected);
     }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -29,6 +29,9 @@ public class CaseMatchingJsonService {
     private static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_sub_query_a.json";
     private static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_sub_query_b.json";
 
+    private static final String QUERY = "query";
+    private static final String DECEASED_ALIAS = ":deceasedAlias";
+    private static final String MULTI_MATCH = "/multi_match";
 
     private final FileSystemResourceService fileSystemResourceService;
     private final JsonObjectUtils jsonObjectUtils;
@@ -106,16 +109,16 @@ public class CaseMatchingJsonService {
         final JSONObject forenameMatch = jsonObjectUtils.findObjectInQuery(
                 aliasNameAQuery,
                 new JSONPointer("/bool/must/0/multi_match"),
-                "query",
-                ":deceasedAlias");
-        forenameMatch.put("query", alias);
+                QUERY,
+                DECEASED_ALIAS);
+        forenameMatch.put(QUERY, alias);
 
         final JSONObject surnameMatch = jsonObjectUtils.findObjectInQuery(
                 aliasNameAQuery,
                 new JSONPointer("/bool/must/1/multi_match"),
-                "query",
-                ":deceasedAlias");
-        surnameMatch.put("query", alias);
+                QUERY,
+                DECEASED_ALIAS);
+        surnameMatch.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameAQuery);
     }
@@ -127,16 +130,16 @@ public class CaseMatchingJsonService {
         final JSONObject forenameMatch = jsonObjectUtils.findObjectInQuery(
                 aliasNameBQuery,
                 new JSONPointer("/bool/must/0/multi_match"),
-                "query",
-                ":deceasedAlias");
-        forenameMatch.put("query", alias);
+                QUERY,
+                DECEASED_ALIAS);
+        forenameMatch.put(QUERY, alias);
 
         final JSONObject surnameMatch = jsonObjectUtils.findObjectInQuery(
                 aliasNameBQuery,
                 new JSONPointer("/bool/must/1/multi_match"),
-                "query",
-                ":deceasedAlias");
-        surnameMatch.put("query", alias);
+                QUERY,
+                DECEASED_ALIAS);
+        surnameMatch.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameBQuery);
     }
@@ -148,10 +151,10 @@ public class CaseMatchingJsonService {
 
         final JSONObject match = jsonObjectUtils.findObjectInQuery(
                 aliasNameAliasAQuery,
-                new JSONPointer("/multi_match"),
-                "query",
-                ":deceasedAlias");
-        match.put("query", alias);
+                new JSONPointer(MULTI_MATCH),
+                QUERY,
+                DECEASED_ALIAS);
+        match.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameAliasAQuery);
     }
@@ -163,10 +166,10 @@ public class CaseMatchingJsonService {
 
         final JSONObject match = jsonObjectUtils.findObjectInQuery(
                 aliasNameAliasBQuery,
-                new JSONPointer("/multi_match"),
-                "query",
-                ":deceasedAlias");
-        match.put("query", alias);
+                new JSONPointer(MULTI_MATCH),
+                QUERY,
+                DECEASED_ALIAS);
+        match.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameAliasBQuery);
     }
@@ -178,10 +181,10 @@ public class CaseMatchingJsonService {
 
         final JSONObject match = jsonObjectUtils.findObjectInQuery(
                 aliasNameSolsAliasAQuery,
-                new JSONPointer("/multi_match"),
-                "query",
-                ":deceasedAlias");
-        match.put("query", alias);
+                new JSONPointer(MULTI_MATCH),
+                QUERY,
+                DECEASED_ALIAS);
+        match.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameSolsAliasAQuery);
     }
@@ -193,10 +196,10 @@ public class CaseMatchingJsonService {
 
         final JSONObject match = jsonObjectUtils.findObjectInQuery(
                 aliasNameSolsAliasBQuery,
-                new JSONPointer("/multi_match"),
-                "query",
-                ":deceasedAlias");
-        match.put("query", alias);
+                new JSONPointer(MULTI_MATCH),
+                QUERY,
+                DECEASED_ALIAS);
+        match.put(QUERY, alias);
 
         return new CaseMatchingJson(jsonObjectUtils, aliasNameSolsAliasBQuery);
     }

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingJsonService.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.probate.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONPointer;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -15,19 +15,22 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
+@Component
 public class CaseMatchingJsonService {
+    private static final String JSON_BASE = "templates/elasticsearch/caseMatching/json/";
 
-    private static final String ES_BASE = "templates/elasticsearch/caseMatching/json/matching_base.json";
+    private static final String ES_BASE = JSON_BASE + "matching_base.json";
 
-    private static final String DOB_BASE = "templates/elasticsearch/caseMatching/json/deceased_dob_sub_query.json";
-    private static final String DOD_BASE = "templates/elasticsearch/caseMatching/json/deceased_dod_sub_query.json";
+    private static final String DOB_BASE = JSON_BASE + "deceased_dob_sub_query.json";
+    private static final String DOD_BASE = JSON_BASE + "deceased_dod_sub_query.json";
 
-    private static final String ALIAS_NAME_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_sub_query_a.json";
-    private static final String ALIAS_NAME_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_sub_query_b.json";
-    private static final String ALIAS_NAME_ALIAS_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_a.json";
-    private static final String ALIAS_NAME_ALIAS_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_b.json";
-    private static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_a.json";
-    private static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = "templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_b.json";
+    private static final String ALIAS_NAME_A_BASE = JSON_BASE + "aliases_sub_query_a.json";
+    private static final String ALIAS_NAME_B_BASE = JSON_BASE + "aliases_sub_query_b.json";
+    private static final String ALIAS_NAME_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_a.json";
+    private static final String ALIAS_NAME_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_list_sub_query_b.json";
+    private static final String ALIAS_NAME_SOLS_ALIAS_A_BASE = JSON_BASE + "aliases_to_aliases_sub_query_a.json";
+    private static final String ALIAS_NAME_SOLS_ALIAS_B_BASE = JSON_BASE + "aliases_to_aliases_sub_query_b.json";
+
 
     private final FileSystemResourceService fileSystemResourceService;
     private final JsonObjectUtils jsonObjectUtils;
@@ -375,6 +378,7 @@ public class CaseMatchingJsonService {
         }
     }
 
+    @Component
     static class JsonObjectUtils {
         private JSONObject findObjectInQuery(
                 final JSONObject queryObject,

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.probate.service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.stereotype.Service;
@@ -12,11 +11,11 @@ import uk.gov.hmcts.probate.service.CaseMatchingJsonService.CaseMatchingJson;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class CaseMatchingService {
 
@@ -34,8 +33,18 @@ public class CaseMatchingService {
     private final CaseMatchBuilderService caseMatchBuilderService;
     private final CaseMatchingJsonService caseMatchingJsonService;
 
-    public List<CaseMatch> findMatches(CaseType caseType, CaseMatchingCriteria criteria) {
+    public CaseMatchingService(
+            final FileSystemResourceService fileSystemResourceService,
+            final ElasticSearchService elasticSearchService,
+            final CaseMatchBuilderService caseMatchBuilderService,
+            final CaseMatchingJsonService caseMatchingJsonService) {
+        this.fileSystemResourceService = Objects.requireNonNull(fileSystemResourceService);
+        this.elasticSearchService = Objects.requireNonNull(elasticSearchService);
+        this.caseMatchBuilderService = Objects.requireNonNull(caseMatchBuilderService);
+        this.caseMatchingJsonService = Objects.requireNonNull(caseMatchingJsonService);
+    }
 
+    MatchedCases oldFindMatches(final CaseType caseType, final CaseMatchingCriteria criteria) {
         String optionalAliasesToNameQuery = criteria.getDeceasedAliases().stream()
                 .map(alias -> getAliasesToNameSubQueryTemplate().replace(":deceasedAliases", alias))
                 .collect(Collectors.joining());
@@ -64,11 +73,12 @@ public class CaseMatchingService {
                 .replace(":optionalDeceasedDateOfDeath", optionalDeceasedDateOfDeath)
                 .replace(":optionalAliasesToNameQuery", optionalAliasesToNameQuery)
                 .replace(":optionalAliasesToAliasesQuery", optionalAliasesToAliasesQuery)
-                .replace(":optionalAliasesToAliasesNameListQuery",optionalAliasesToAliasesNameListQuery);
+                .replace(":optionalAliasesToAliasesNameListQuery", optionalAliasesToAliasesNameListQuery);
 
-        MatchedCases matchedCases = elasticSearchService.runQuery(caseType, stringQuery);
+        return elasticSearchService.runQuery(caseType, stringQuery);
+    }
 
-
+    MatchedCases newFindMatches(final CaseType caseType, final CaseMatchingCriteria criteria) {
         final CaseMatchingJson baseQuery = caseMatchingJsonService.getBaseQuery();
 
         final CaseMatchingJson withForenames = baseQuery.withDeceasedForenames(criteria.getDeceasedForenames());
@@ -91,7 +101,13 @@ public class CaseMatchingService {
 
         final JSONObject jsonQuery = withAliases.stealJson().orElseThrow();
 
-        final MatchedCases matchedCasesJson = elasticSearchService.runJsonQuery(caseType, jsonQuery);
+        return elasticSearchService.runJsonQuery(caseType, jsonQuery);
+    }
+
+    public List<CaseMatch> findMatches(CaseType caseType, CaseMatchingCriteria criteria) {
+
+        final MatchedCases newMatchedCases = newFindMatches(caseType, criteria);
+        final MatchedCases matchedCases = oldFindMatches(caseType, criteria);
 
         String caseIds = matchedCases.getCases().stream()
                 .map(c -> Optional.ofNullable(c.getId())

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -77,9 +77,19 @@ public class CaseMatchingService {
 
         final CaseMatchingJson withFullName = withSurname.withDeceasedFullname(criteria.getDeceasedFullName());
 
+        final Optional<CaseMatchingJson> birthSubquery = caseMatchingJsonService.getDateOfBirthSubquery(
+                criteria.getDeceasedDateOfBirthRaw());
+        final CaseMatchingJson withBirth = withFullName.withDateOfBirth(birthSubquery);
 
+        final Optional<CaseMatchingJson> deathSubquery = caseMatchingJsonService.getDateOfDeathSubquery(
+                criteria.getDeceasedDateOfDeathRaw());
+        final CaseMatchingJson withDeath = withFullName.withDateOfDeath(deathSubquery);
 
-        final JSONObject jsonQuery = withFullName.stealJson().orElseThrow();
+        final List<CaseMatchingJson> aliasesSubQueries = caseMatchingJsonService.getAliasesSubqueries(
+                criteria.getDeceasedAliases());
+        final CaseMatchingJson withAliases = withDeath.withAliases(aliasesSubQueries);
+
+        final JSONObject jsonQuery = withAliases.stealJson().orElseThrow();
 
         final MatchedCases matchedCasesJson = elasticSearchService.runJsonQuery(caseType, jsonQuery);
 

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -2,11 +2,13 @@ package uk.gov.hmcts.probate.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.probate.model.CaseType;
 import uk.gov.hmcts.probate.model.ccd.CaseMatch;
 import uk.gov.hmcts.probate.model.ccd.raw.casematching.MatchedCases;
 import uk.gov.hmcts.probate.model.criterion.CaseMatchingCriteria;
+import uk.gov.hmcts.probate.service.CaseMatchingJsonService.CaseMatchingJson;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,9 +28,11 @@ public class CaseMatchingService {
     private static final String ES_DECEASED_DOB_SUB_QUERY = "deceased_dob_sub_query.json";
     private static final String ES_DECEASED_DOD_SUB_QUERY = "deceased_dod_sub_query.json";
 
+
     private final FileSystemResourceService fileSystemResourceService;
     private final ElasticSearchService elasticSearchService;
     private final CaseMatchBuilderService caseMatchBuilderService;
+    private final CaseMatchingJsonService caseMatchingJsonService;
 
     public List<CaseMatch> findMatches(CaseType caseType, CaseMatchingCriteria criteria) {
 
@@ -52,7 +56,7 @@ public class CaseMatchingService {
                 .map(data -> getDoDTemplate().replace(":deceasedDateOfDeath", criteria.getDeceasedDateOfDeath()))
                 .orElse("");
 
-        String jsonQuery = getQueryTemplate()
+        String stringQuery = getQueryTemplateString()
                 .replace(":deceasedForenames", criteria.getDeceasedForenames())
                 .replace(":deceasedSurname", criteria.getDeceasedSurname())
                 .replace(":deceasedFullName", criteria.getDeceasedFullName())
@@ -62,7 +66,22 @@ public class CaseMatchingService {
                 .replace(":optionalAliasesToAliasesQuery", optionalAliasesToAliasesQuery)
                 .replace(":optionalAliasesToAliasesNameListQuery",optionalAliasesToAliasesNameListQuery);
 
-        MatchedCases matchedCases = elasticSearchService.runQuery(caseType, jsonQuery);
+        MatchedCases matchedCases = elasticSearchService.runQuery(caseType, stringQuery);
+
+
+        final CaseMatchingJson baseQuery = caseMatchingJsonService.getBaseQuery();
+
+        final CaseMatchingJson withForenames = baseQuery.withDeceasedForenames(criteria.getDeceasedForenames());
+
+        final CaseMatchingJson withSurname = withForenames.withDeceasedSurname(criteria.getDeceasedSurname());
+
+        final CaseMatchingJson withFullName = withSurname.withDeceasedFullname(criteria.getDeceasedFullName());
+
+
+
+        final JSONObject jsonQuery = withFullName.stealJson().orElseThrow();
+
+        final MatchedCases matchedCasesJson = elasticSearchService.runJsonQuery(caseType, jsonQuery);
 
         String caseIds = matchedCases.getCases().stream()
                 .map(c -> Optional.ofNullable(c.getId())
@@ -84,7 +103,7 @@ public class CaseMatchingService {
                 .collect(Collectors.toList());
     }
 
-    private String getQueryTemplate() {
+    private String getQueryTemplateString() {
         return fileSystemResourceService.getFileFromResourceAsString(TEMPLATE_DIRECTORY + ES_QUERY);
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -83,7 +83,7 @@ public class CaseMatchingService {
 
         final Optional<CaseMatchingJson> deathSubquery = caseMatchingJsonService.getDateOfDeathSubquery(
                 criteria.getDeceasedDateOfDeathRaw());
-        final CaseMatchingJson withDeath = withFullName.withDateOfDeath(deathSubquery);
+        final CaseMatchingJson withDeath = withBirth.withDateOfDeath(deathSubquery);
 
         final List<CaseMatchingJson> aliasesSubQueries = caseMatchingJsonService.getAliasesSubqueries(
                 criteria.getDeceasedAliases());

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -106,8 +106,11 @@ public class CaseMatchingService {
 
     public List<CaseMatch> findMatches(CaseType caseType, CaseMatchingCriteria criteria) {
 
+        log.info("running new findMatches for case type {}", caseType);
         final MatchedCases newMatchedCases = newFindMatches(caseType, criteria);
+        log.info("completed new findMatches for case type {}", caseType);
         final MatchedCases matchedCases = oldFindMatches(caseType, criteria);
+        log.info("completed old findMatches for case type {}", caseType);
 
         String caseIds = matchedCases.getCases().stream()
                 .map(c -> Optional.ofNullable(c.getId())

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -32,16 +32,19 @@ public class CaseMatchingService {
     private final ElasticSearchService elasticSearchService;
     private final CaseMatchBuilderService caseMatchBuilderService;
     private final CaseMatchingJsonService caseMatchingJsonService;
+    private final FeatureToggleService featureToggleService;
 
     public CaseMatchingService(
             final FileSystemResourceService fileSystemResourceService,
             final ElasticSearchService elasticSearchService,
             final CaseMatchBuilderService caseMatchBuilderService,
-            final CaseMatchingJsonService caseMatchingJsonService) {
+            final CaseMatchingJsonService caseMatchingJsonService,
+            final FeatureToggleService featureToggleService) {
         this.fileSystemResourceService = Objects.requireNonNull(fileSystemResourceService);
         this.elasticSearchService = Objects.requireNonNull(elasticSearchService);
         this.caseMatchBuilderService = Objects.requireNonNull(caseMatchBuilderService);
         this.caseMatchingJsonService = Objects.requireNonNull(caseMatchingJsonService);
+        this.featureToggleService = Objects.requireNonNull(featureToggleService);
     }
 
     MatchedCases oldFindMatches(final CaseType caseType, final CaseMatchingCriteria criteria) {
@@ -105,12 +108,12 @@ public class CaseMatchingService {
     }
 
     public List<CaseMatch> findMatches(CaseType caseType, CaseMatchingCriteria criteria) {
-
-        log.info("running new findMatches for case type {}", caseType);
-        final MatchedCases newMatchedCases = newFindMatches(caseType, criteria);
-        log.info("completed new findMatches for case type {}", caseType);
-        final MatchedCases matchedCases = oldFindMatches(caseType, criteria);
-        log.info("completed old findMatches for case type {}", caseType);
+        final MatchedCases matchedCases;
+        if (featureToggleService.useJsonLibForCaseMatching()) {
+            matchedCases = newFindMatches(caseType, criteria);
+        } else {
+            matchedCases = oldFindMatches(caseType, criteria);
+        }
 
         String caseIds = matchedCases.getCases().stream()
                 .map(c -> Optional.ofNullable(c.getId())

--- a/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/CaseMatchingService.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.probate.model.CaseType;
 import uk.gov.hmcts.probate.model.ccd.CaseMatch;
 import uk.gov.hmcts.probate.model.ccd.raw.casematching.MatchedCases;
 import uk.gov.hmcts.probate.model.criterion.CaseMatchingCriteria;
-import uk.gov.hmcts.probate.service.CaseMatchingJsonService.CaseMatchingJson;
+import uk.gov.hmcts.probate.query.CaseMatchingJson;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
@@ -28,6 +28,7 @@ public class ElasticSearchService {
     private final HttpHeadersFactory headers;
 
     public MatchedCases runQuery(CaseType caseType, String jsonQuery) {
+        log.info("ElasticSearchService runQuery caseType: {} jsonQuery:\nv\n{}\n^", caseType, jsonQuery);
         log.debug("ElasticSearchService runQuery: " + jsonQuery);
         URI uri = UriComponentsBuilder
             .fromHttpUrl(ccdDataStoreAPIConfiguration.getHost() + ccdDataStoreAPIConfiguration.getCaseMatchingPath())

--- a/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.probate.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -43,5 +44,9 @@ public class ElasticSearchService {
         }
 
         return matchedCases;
+    }
+
+    public MatchedCases runJsonQuery(CaseType caseType, JSONObject jsonQuery) {
+        return runQuery(caseType, jsonQuery.toString());
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/ElasticSearchService.java
@@ -28,7 +28,6 @@ public class ElasticSearchService {
     private final HttpHeadersFactory headers;
 
     public MatchedCases runQuery(CaseType caseType, String jsonQuery) {
-        log.info("ElasticSearchService runQuery caseType: {} jsonQuery:\nv\n{}\n^", caseType, jsonQuery);
         log.debug("ElasticSearchService runQuery: " + jsonQuery);
         URI uri = UriComponentsBuilder
             .fromHttpUrl(ccdDataStoreAPIConfiguration.getHost() + ccdDataStoreAPIConfiguration.getCaseMatchingPath())
@@ -48,6 +47,6 @@ public class ElasticSearchService {
     }
 
     public MatchedCases runJsonQuery(CaseType caseType, JSONObject jsonQuery) {
-        return runQuery(caseType, jsonQuery.toString());
+        return runQuery(caseType, jsonQuery.toString(0));
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -22,6 +22,7 @@ public class FeatureToggleService {
     private static final String UNSUBMITTED_APPLICATION_TOGGLE = "probate-cron-unsubmitted-application";
     private static final String DECLARATION_NOT_SIGNED_TOGGLE = "probate-cron-declaration-not-signed";
     private static final String NFI_DATA_EXTRACT_TOGGLE = "probate-nfi-data-extract";
+    private static final String USE_JSON_LIB_FOR_CASE_MATCHING = "probate-use-json-lib-for-case-matching";
 
     @Autowired
     public FeatureToggleService(LDClient ldClient, @Value("${ld.user.key}") String ldUserKey,
@@ -109,5 +110,10 @@ public class FeatureToggleService {
     public boolean isNfiDataExtractFeatureToggleOn() {
         return this.isFeatureToggleOn(
                 NFI_DATA_EXTRACT_TOGGLE, false);
+    }
+
+    public boolean useJsonLibForCaseMatching() {
+        return this.isFeatureToggleOn(
+                USE_JSON_LIB_FOR_CASE_MATCHING, false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
@@ -36,7 +36,6 @@ public class JsonObjectUtils {
         if (!(fromPointer instanceof JSONArray)) {
             throw new IllegalStateException("Expected JSON array but got " + fromPointer);
         }
-        final JSONArray array = (JSONArray) fromPointer;
-        return array;
+        return (JSONArray) fromPointer;
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.probate.service;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonObjectUtils {
+    public JSONObject findObjectInQuery(
+            final JSONObject queryObject,
+            final JSONPointer pointer,
+            final String expectKey,
+            final String expectValue) {
+        final Object fromPointer = queryObject.query(pointer);
+        if (!(fromPointer instanceof JSONObject)) {
+            throw new IllegalStateException("Expected JSON object but got " + fromPointer);
+        }
+        final JSONObject subObject = (JSONObject) fromPointer;
+        if (!subObject.has(expectKey)) {
+            throw new IllegalStateException(
+                    "Expected JSON object with \"" + expectKey + "\" key but got " + subObject);
+        }
+        if (!subObject.get(expectKey).equals(expectValue)) {
+            throw new IllegalStateException(
+                    "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue
+                            + "\" but got " + subObject);
+        }
+        return subObject;
+    }
+
+    public JSONArray findArrayInQuery(
+            final JSONObject queryObject,
+            final JSONPointer pointer) {
+        final Object fromPointer = queryObject.query(pointer);
+        if (!(fromPointer instanceof JSONArray)) {
+            throw new IllegalStateException("Expected JSON array but got " + fromPointer);
+        }
+        final JSONArray array = (JSONArray) fromPointer;
+        return array;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/JsonObjectUtils.java
@@ -4,6 +4,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONPointer;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.probate.exception.JsonObjectUtilsException;
+import uk.gov.hmcts.probate.exception.JsonObjectUtilsException.Cause;
 
 @Component
 public class JsonObjectUtils {
@@ -14,17 +16,21 @@ public class JsonObjectUtils {
             final String expectValue) {
         final Object fromPointer = queryObject.query(pointer);
         if (!(fromPointer instanceof JSONObject)) {
-            throw new IllegalStateException("Expected JSON object but got " + fromPointer);
+            throw new JsonObjectUtilsException(
+                    "Expected JSON object but got " + fromPointer,
+                    Cause.WRONG_TYPE);
         }
         final JSONObject subObject = (JSONObject) fromPointer;
         if (!subObject.has(expectKey)) {
-            throw new IllegalStateException(
-                    "Expected JSON object with \"" + expectKey + "\" key but got " + subObject);
+            throw new JsonObjectUtilsException(
+                    "Expected JSON object with \"" + expectKey + "\" key but got " + subObject,
+                    Cause.NO_SUBKEY);
         }
         if (!subObject.get(expectKey).equals(expectValue)) {
-            throw new IllegalStateException(
+            throw new JsonObjectUtilsException(
                     "Expected JSON object with \"" + expectKey + "\" key with value \"" + expectValue
-                            + "\" but got " + subObject);
+                            + "\" but got " + subObject,
+                    Cause.MISMATCHED_SUBKEY);
         }
         return subObject;
     }
@@ -34,7 +40,9 @@ public class JsonObjectUtils {
             final JSONPointer pointer) {
         final Object fromPointer = queryObject.query(pointer);
         if (!(fromPointer instanceof JSONArray)) {
-            throw new IllegalStateException("Expected JSON array but got " + fromPointer);
+            throw new JsonObjectUtilsException(
+                    "Expected JSON array but got " + fromPointer,
+                    Cause.WRONG_TYPE);
         }
         return (JSONArray) fromPointer;
     }

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_sub_query_a.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_sub_query_a.json
@@ -1,0 +1,24 @@
+{
+  "bool": {
+    "must": [
+      {
+        "multi_match": {
+          "query": ":deceasedAlias",
+          "boost": 2,
+          "fields": [
+            "data.deceasedForenames"
+          ]
+        }
+      },
+      {
+        "multi_match": {
+          "query": ":deceasedAlias",
+          "boost": 2,
+          "fields": [
+            "data.deceasedSurname"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_sub_query_b.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_sub_query_b.json
@@ -1,0 +1,26 @@
+{
+  "bool": {
+    "must": [
+      {
+        "multi_match": {
+          "query": ":deceasedAlias",
+          "fuzziness": 2,
+          "prefix_length": 0,
+          "fields": [
+            "data.deceasedForenames"
+          ]
+        }
+      },
+      {
+        "multi_match": {
+          "query": ":deceasedAlias",
+          "fuzziness": 2,
+          "prefix_length": 0,
+          "fields": [
+            "data.deceasedSurname"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_a.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_a.json
@@ -1,0 +1,10 @@
+{
+  "multi_match": {
+    "query": ":deceasedAlias",
+    "operator": "and",
+    "boost": 2,
+    "fields": [
+      "data.deceasedFullAliasNameList.*"
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_b.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_list_sub_query_b.json
@@ -1,0 +1,11 @@
+{
+  "multi_match": {
+    "query": ":deceasedAlias",
+    "operator": "and",
+    "fuzziness": 2,
+    "prefix_length": 0,
+    "fields": [
+      "data.deceasedFullAliasNameList.*"
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_a.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_a.json
@@ -1,0 +1,10 @@
+{
+  "multi_match": {
+    "query": ":deceasedAlias",
+    "operator": "and",
+    "boost": 2,
+    "fields": [
+      "data.solsDeceasedAliasNamesList.*"
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_b.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/aliases_to_aliases_sub_query_b.json
@@ -1,0 +1,11 @@
+{
+  "multi_match": {
+    "query": ":deceasedAlias",
+    "operator": "and",
+    "fuzziness": 2,
+    "prefix_length": 0,
+    "fields": [
+      "data.solsDeceasedAliasNamesList.*"
+    ]
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/deceased_dob_sub_query.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/deceased_dob_sub_query.json
@@ -1,0 +1,24 @@
+{
+  "bool": {
+    "should": [
+      {
+        "term": {
+          "data.deceasedDateOfBirth": {
+            "value": ":deceasedDateOfBirth"
+          }
+        }
+      },
+      {
+        "bool": {
+          "must_not": {
+            "exists": {
+              "field": "data.deceasedDateOfBirth"
+            }
+          }
+        }
+      }
+    ],
+    "minimum_should_match": 1
+  }
+}
+

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/deceased_dod_sub_query.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/deceased_dod_sub_query.json
@@ -1,0 +1,93 @@
+{
+  "bool": {
+    "should": [
+      {
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "must_not": {
+                  "exists": {
+                    "field": "data.deceasedDateOfDeath"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must_not": {
+                        "exists": {
+                          "field": "data.deceasedDateOfDeath"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "range": {
+                      "data.deceasedDateOfDeath": {
+                        "gte": ":deceasedDateOfDeath||-3d",
+                        "lte": ":deceasedDateOfDeath||+3d"
+                      }
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ],
+          "minimum_should_match": 1
+        }
+      },
+      {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": {
+                  "exists": {
+                    "field": "data.deceasedDateOfDeath"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "must": {
+                  "exists": {
+                    "field": "data.deceasedDateOfDeath2"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "must": {
+                  "range": {
+                    "data.deceasedDateOfDeath": {
+                      "lte": ":deceasedDateOfDeath"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "must": {
+                  "range": {
+                    "data.deceasedDateOfDeath2": {
+                      "gte": ":deceasedDateOfDeath"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "minimum_should_match": 1
+  }
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/matching_base.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/matching_base.json
@@ -1,0 +1,229 @@
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "match": {
+            "state": "PAAppCreated"
+          }
+        },
+        {
+          "match": {
+            "state": "Pending"
+          }
+        }
+      ],
+      "should": [
+        {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": ":deceasedForenames",
+                  "boost": 2,
+                  "fields": [
+                    "data.deceasedForenames"
+                  ]
+                }
+              },
+              {
+                "multi_match": {
+                  "query": ":deceasedSurname",
+                  "boost": 2,
+                  "fields": [
+                    "data.deceasedSurname"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": ":deceasedForenames",
+                  "fuzziness": 2,
+                  "prefix_length": 0,
+                  "fields": [
+                    "data.deceasedForenames"
+                  ]
+                }
+              },
+              {
+                "multi_match": {
+                  "query": ":deceasedSurname",
+                  "fuzziness": 2,
+                  "prefix_length": 0,
+                  "fields": [
+                    "data.deceasedSurname"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "PLACEHOLDER": ":optionalAliasesToNameQuery"
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": ":deceasedForenames",
+                  "boost": 2,
+                  "fields": [
+                    "data.deceasedAliasNameList.*.Forenames"
+                  ]
+                }
+              },
+              {
+                "multi_match": {
+                  "query": ":deceasedSurname",
+                  "boost": 2,
+                  "fields": [
+                    "data.deceasedAliasNameList.*.LastName"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": ":deceasedForenames",
+                  "fuzziness": 2,
+                  "prefix_length": 0,
+                  "fields": [
+                    "data.deceasedAliasNameList.*.Forenames"
+                  ]
+                }
+              },
+              {
+                "multi_match": {
+                  "query": ":deceasedSurname",
+                  "fuzziness": 2,
+                  "prefix_length": 0,
+                  "fields": [
+                    "data.deceasedAliasNameList.*.LastName"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "boost": 2,
+            "fields": [
+              "data.solsDeceasedAliasNamesList.*"
+            ]
+          }
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "fuzziness": 2,
+            "prefix_length": 0,
+            "fields": [
+              "data.solsDeceasedAliasNamesList.*"
+            ]
+          }
+        },
+        {
+          "PLACEHOLDER": ":optionalAliasesToAliasesQuery"
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "boost": 2,
+            "fields": [
+              "data.deceasedFullAliasNameList.*"
+            ]
+          }
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "fuzziness": 2,
+            "prefix_length": 0,
+            "fields": [
+              "data.deceasedFullAliasNameList.*"
+            ]
+          }
+        },
+        {
+          "PLACEHOLDER": ":optionalAliasesToAliasesNameListQuery"
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "boost": 2,
+            "fields": [
+              "data.alias_names"
+            ]
+          }
+        },
+        {
+          "multi_match": {
+            "query": ":deceasedFullName",
+            "operator": "and",
+            "fuzziness": 2,
+            "prefix_length": 0,
+            "fields": [
+              "data.alias_names"
+            ]
+          }
+        }
+      ],
+      "minimum_should_match": 1,
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "PLACEHOLDER": ":optionalDeceasedDateOfBirth"
+            },
+            {
+              "PLACEHOLDER": ":optionalDeceasedDateOfDeath"
+            },
+            {
+              "bool": {
+                "should": [
+                  {
+                    "bool": {
+                      "must_not": {
+                        "exists": {
+                          "field": "data.imported_to_ccd"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "match": {
+                      "data.imported_to_ccd": {
+                        "query": "N"
+                      }
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "size": 100
+}

--- a/src/main/resources/templates/elasticsearch/caseMatching/json/matching_base.json
+++ b/src/main/resources/templates/elasticsearch/caseMatching/json/matching_base.json
@@ -65,9 +65,6 @@
           }
         },
         {
-          "PLACEHOLDER": ":optionalAliasesToNameQuery"
-        },
-        {
           "bool": {
             "must": [
               {
@@ -139,9 +136,6 @@
           }
         },
         {
-          "PLACEHOLDER": ":optionalAliasesToAliasesQuery"
-        },
-        {
           "multi_match": {
             "query": ":deceasedFullName",
             "operator": "and",
@@ -161,9 +155,6 @@
               "data.deceasedFullAliasNameList.*"
             ]
           }
-        },
-        {
-          "PLACEHOLDER": ":optionalAliasesToAliasesNameListQuery"
         },
         {
           "multi_match": {
@@ -191,12 +182,6 @@
       "filter": {
         "bool": {
           "must": [
-            {
-              "PLACEHOLDER": ":optionalDeceasedDateOfBirth"
-            },
-            {
-              "PLACEHOLDER": ":optionalDeceasedDateOfDeath"
-            },
             {
               "bool": {
                 "should": [

--- a/src/test/java/uk/gov/hmcts/probate/query/CaseMatchingJsonTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/query/CaseMatchingJsonTest.java
@@ -1,0 +1,307 @@
+package uk.gov.hmcts.probate.query;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.probate.service.JsonObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CaseMatchingJsonTest {
+    @Mock
+    JsonObjectUtils jsonObjectUtilsMock;
+    @Mock
+    JSONObject jsonMock;
+
+    CaseMatchingJson caseMatchingJson;
+
+    AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        caseMatchingJson = new CaseMatchingJson(jsonObjectUtilsMock, jsonMock);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+
+    private static class JsonPointerMatcher implements ArgumentMatcher<JSONPointer> {
+        final String expPath;
+
+        public JsonPointerMatcher(String expPath) {
+            this.expPath = expPath;
+        }
+
+        @Override
+        public boolean matches(JSONPointer argument) {
+            return argument.toString().equals(expPath);
+        }
+    }
+
+    @Test
+    void testDeceasedForenames() {
+        final String forename = "forename";
+        final JSONObject forenameJson = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forenameJson);
+
+        final CaseMatchingJson result = caseMatchingJson.withDeceasedForenames(forename);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(forenameJson, times(4)).put("query", forename),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/0/bool/must/0/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/1/bool/must/0/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/2/bool/must/0/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/3/bool/must/0/multi_match")),
+                        any(),
+                        any()));
+    }
+
+    @Test
+    void testDeceasedSurname() {
+        final String surname = "surname";
+        final JSONObject surnameJson = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(surnameJson);
+
+        final CaseMatchingJson result = caseMatchingJson.withDeceasedSurname(surname);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(surnameJson, times(4)).put("query", surname),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/0/bool/must/1/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/1/bool/must/1/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/2/bool/must/1/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/3/bool/must/1/multi_match")),
+                        any(),
+                        any()));
+    }
+
+    @Test
+    void testDeceasedFullname() {
+        final String fullname = "full name";
+        final JSONObject fullnameJson = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(fullnameJson);
+
+        final CaseMatchingJson result = caseMatchingJson.withDeceasedFullname(fullname);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(fullnameJson, times(6)).put("query", fullname),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/4/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/5/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/6/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/7/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/8/multi_match")),
+                        any(),
+                        any()),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/should/9/multi_match")),
+                        any(),
+                        any()));
+    }
+
+    @Test
+    void testDateOfBirthSet() {
+        final CaseMatchingJson dateOfBirth = mock();
+        final JSONObject dateOfBirthJson = mock();
+        final Optional<CaseMatchingJson> dateOfBirthOpt = Optional.of(dateOfBirth);
+
+        final JSONArray queryArray = mock();
+
+        when(dateOfBirth.stealJson())
+                .thenReturn(Optional.of(dateOfBirthJson));
+
+        when(jsonObjectUtilsMock.findArrayInQuery(any(), any()))
+                .thenReturn(queryArray);
+
+        final CaseMatchingJson result = caseMatchingJson.withDateOfBirth(dateOfBirthOpt);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(queryArray).put(dateOfBirthJson),
+                () -> verify(jsonObjectUtilsMock).findArrayInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/filter/bool/must"))));
+    }
+
+    @Test
+    void testDateOfBirthUnset() {
+        final Optional<CaseMatchingJson> dateOfBirth = Optional.empty();
+
+        final CaseMatchingJson result = caseMatchingJson.withDateOfBirth(dateOfBirth);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(jsonObjectUtilsMock, never()).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(jsonObjectUtilsMock, never()).findArrayInQuery(any(), any()));
+    }
+
+    @Test
+    void testDateOfDeathSet() {
+        final CaseMatchingJson dateOfDeath = mock();
+        final JSONObject dateOfDeathJson = mock();
+        final Optional<CaseMatchingJson> dateOfDeathOpt = Optional.of(dateOfDeath);
+
+        final JSONArray queryArray = mock();
+
+        when(dateOfDeath.stealJson())
+                .thenReturn(Optional.of(dateOfDeathJson));
+
+        when(jsonObjectUtilsMock.findArrayInQuery(any(), any()))
+                .thenReturn(queryArray);
+
+        final CaseMatchingJson result = caseMatchingJson.withDateOfDeath(dateOfDeathOpt);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(queryArray).put(dateOfDeathJson),
+                () -> verify(jsonObjectUtilsMock).findArrayInQuery(
+                        eq(jsonMock),
+                        argThat(new JsonPointerMatcher("/query/bool/filter/bool/must"))));
+    }
+
+    @Test
+    void testDateOfDeathUnset() {
+        final Optional<CaseMatchingJson> dateOfDeath = Optional.empty();
+
+        final CaseMatchingJson result = caseMatchingJson.withDateOfDeath(dateOfDeath);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(jsonObjectUtilsMock, never()).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(jsonObjectUtilsMock, never()).findArrayInQuery(any(), any()));
+    }
+
+    @Test
+    void testWithAliasesAddsAllAliases() {
+        final int aliasCount = RandomUtils.insecure().randomInt(1, 16);
+
+        final JSONArray queryArray = mock();
+        when(jsonObjectUtilsMock.findArrayInQuery(any(), any()))
+                .thenReturn(queryArray);
+
+        final List<CaseMatchingJson> aliases = new ArrayList<>();
+        final List<Executable> verifications = new ArrayList<>();
+        for (int i = 0; i < aliasCount; i++) {
+            final CaseMatchingJson alias = mock();
+            final JSONObject aliasJson = mock();
+            when(alias.stealJson())
+                    .thenReturn(Optional.of(aliasJson));
+            verifications.add(() -> verify(queryArray).put(aliasJson));
+
+            aliases.add(alias);
+        }
+
+        final CaseMatchingJson result = caseMatchingJson.withAliases(aliases);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(jsonObjectUtilsMock, never()).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(jsonObjectUtilsMock)
+                        .findArrayInQuery(eq(jsonMock), argThat(new JsonPointerMatcher("/query/bool/should"))));
+        assertAll(verifications);
+    }
+
+    @Test
+    void testWithAliasesEmptyAliases() {
+        final List<CaseMatchingJson> aliases = Collections.emptyList();
+
+        final CaseMatchingJson result = caseMatchingJson.withAliases(aliases);
+
+        assertAll(
+                () -> assertThat(result, not(sameInstance(caseMatchingJson))),
+                () -> verify(jsonObjectUtilsMock, never()).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(jsonObjectUtilsMock, never()).findArrayInQuery(any(), any()));
+    }
+
+    @Test
+    void testStealJsonReturnsOnce() {
+        final Optional<JSONObject> first = caseMatchingJson.stealJson();
+        final Optional<JSONObject> second = caseMatchingJson.stealJson();
+
+        assertAll(
+                () -> assertThat(first, optionalWithValue(sameInstance(jsonMock))),
+                () -> assertThat(second, emptyOptional()));
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingJsonServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingJsonServiceTest.java
@@ -1,0 +1,339 @@
+package uk.gov.hmcts.probate.service;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.probate.query.CaseMatchingJson;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.spotify.hamcrest.optional.OptionalMatchers.emptyOptional;
+import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CaseMatchingJsonServiceTest {
+    @Mock
+    FileSystemResourceService fileSystemResourceServiceMock;
+    @Mock
+    JsonObjectUtils jsonObjectUtilsMock;
+
+    CaseMatchingJsonService caseMatchingJsonService;
+
+    AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        caseMatchingJsonService = new CaseMatchingJsonService(
+                fileSystemResourceServiceMock,
+                jsonObjectUtilsMock);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+
+    @Test
+    void testGetBaseQuery() {
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        caseMatchingJsonService.getBaseQuery();
+
+        verify(fileSystemResourceServiceMock).getFileFromResourceAsString(CaseMatchingJsonService.ES_BASE);
+    }
+
+    @Test
+    void testGetBaseQueryThrowsIfMalformed() {
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{a}");
+
+        assertThrows(
+                JSONException.class,
+                () -> caseMatchingJsonService.getBaseQuery());
+
+        verify(fileSystemResourceServiceMock).getFileFromResourceAsString(CaseMatchingJsonService.ES_BASE);
+    }
+
+    @Test
+    void testDoBSubqueryNullDoB() {
+        final Optional<CaseMatchingJson> actual = caseMatchingJsonService.getDateOfBirthSubquery(null);
+
+        assertThat(actual, emptyOptional());
+    }
+
+    @Test
+    void testDoBSubqueryWithDoB() {
+        final LocalDate birthDate = LocalDate.of(2020, 1, 1);
+        final String birthFormatted = "2020-01-01";
+
+        final JSONObject jsonMock = mock();
+
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(jsonMock);
+
+        final Optional<CaseMatchingJson> actual = caseMatchingJsonService.getDateOfBirthSubquery(birthDate);
+
+        assertAll(
+                () -> assertThat(actual, optionalWithValue()),
+
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.DOB_BASE),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(jsonMock).put("value", birthFormatted));
+    }
+
+    @Test
+    void testDoBSubqueryWithDoBThrowsIfMalformed() {
+        final LocalDate birthDate = LocalDate.of(2020, 1, 1);
+
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{a}");
+
+        assertThrows(
+                JSONException.class,
+                () -> caseMatchingJsonService.getDateOfBirthSubquery(birthDate));
+
+        verify(fileSystemResourceServiceMock).getFileFromResourceAsString(CaseMatchingJsonService.DOB_BASE);
+    }
+
+    @Test
+    void testDoDSubqueryNullDoD() {
+        final Optional<CaseMatchingJson> actual = caseMatchingJsonService.getDateOfDeathSubquery(null);
+
+        assertThat(actual, emptyOptional());
+    }
+
+    @Test
+    void testDoDSubqueryWithDoD() {
+        final LocalDate deathDate = LocalDate.of(2020, 1, 1);
+        final String deathFormatted = "2020-01-01";
+        final String deathFormattedGte = "2020-01-01||-3d";
+        final String deathFormattedLte = "2020-01-01||+3d";
+
+        final JSONObject jsonMockRangeWithin = mock();
+        final JSONObject jsonMockRangeLte = mock();
+        final JSONObject jsonMockRangeGte = mock();
+
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(jsonMockRangeWithin, jsonMockRangeLte, jsonMockRangeGte);
+
+        final Optional<CaseMatchingJson> actual = caseMatchingJsonService.getDateOfDeathSubquery(deathDate);
+
+        assertAll(
+                () -> assertThat(actual, optionalWithValue()),
+
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.DOD_BASE),
+
+                () -> verify(jsonObjectUtilsMock)
+                        .findObjectInQuery(any(), any(), eq("gte"), eq(":deceasedDateOfDeath||-3d")),
+                () -> verify(jsonObjectUtilsMock)
+                        .findObjectInQuery(any(), any(), eq("lte"), eq(":deceasedDateOfDeath")),
+                () -> verify(jsonObjectUtilsMock)
+                        .findObjectInQuery(any(), any(), eq("gte"), eq(":deceasedDateOfDeath")),
+
+                () -> verify(jsonMockRangeWithin).put("gte", deathFormattedGte),
+                () -> verify(jsonMockRangeWithin).put("lte", deathFormattedLte),
+
+                () -> verify(jsonMockRangeLte).put("lte", deathFormatted),
+
+                () -> verify(jsonMockRangeGte).put("gte", deathFormatted));
+    }
+
+    @Test
+    void testDoDSubqueryWithDoDThrowsIfMalformed() {
+        final LocalDate deathDate = LocalDate.of(2020, 1, 1);
+
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{a}");
+
+        assertThrows(
+                JSONException.class,
+                () -> caseMatchingJsonService.getDateOfDeathSubquery(deathDate));
+
+        verify(fileSystemResourceServiceMock).getFileFromResourceAsString(CaseMatchingJsonService.DOD_BASE);
+    }
+
+    @Test
+    void testAliasesSubqueriesEmptyListReturnsEmptyList() {
+        final List<CaseMatchingJson> actual = caseMatchingJsonService.getAliasesSubqueries(List.of());
+
+        assertThat(actual, empty());
+    }
+
+    @Test
+    void testAliasesSubQueriesReturnsSixSubqueriesPerAlias() {
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(mock());
+
+        final List<CaseMatchingJson> actual = caseMatchingJsonService.getAliasesSubqueries(List.of("a"));
+
+        assertAll(
+                () -> assertThat(actual, hasSize(6)),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_A_BASE),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_B_BASE),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_ALIAS_A_BASE),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_ALIAS_B_BASE),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_SOLS_ALIAS_A_BASE),
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_SOLS_ALIAS_B_BASE));
+    }
+
+    @Test
+    void testAliasNameASubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        final JSONObject surname = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename, surname);
+
+        caseMatchingJsonService.getAliasNameASubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_A_BASE),
+                () -> verify(jsonObjectUtilsMock, times(2))
+                        .findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias),
+                () -> verify(surname).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+
+    @Test
+    void testAliasNameBSubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        final JSONObject surname = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename, surname);
+
+        caseMatchingJsonService.getAliasNameBSubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_B_BASE),
+                () -> verify(jsonObjectUtilsMock, times(2))
+                        .findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias),
+                () -> verify(surname).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+
+    @Test
+    void testAliasNameAliasASubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename);
+
+        caseMatchingJsonService.getAliasNameAliasASubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_ALIAS_A_BASE),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+
+    @Test
+    void testAliasNameAliasBSubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename);
+
+        caseMatchingJsonService.getAliasNameAliasBSubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_ALIAS_B_BASE),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+
+    @Test
+    void testAliasNameSolsAliasASubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename);
+
+        caseMatchingJsonService.getAliasNameSolsAliasASubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_SOLS_ALIAS_A_BASE),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+
+    @Test
+    void testAliasNameSolsAliasBSubquery() {
+        final String alias = "alias";
+        when(fileSystemResourceServiceMock.getFileFromResourceAsString(any()))
+                .thenReturn("{}");
+
+        final JSONObject forename = mock();
+        when(jsonObjectUtilsMock.findObjectInQuery(any(), any(), any(), any()))
+                .thenReturn(forename);
+
+        caseMatchingJsonService.getAliasNameSolsAliasBSubquery(alias);
+
+        assertAll(
+                () -> verify(fileSystemResourceServiceMock)
+                        .getFileFromResourceAsString(CaseMatchingJsonService.ALIAS_NAME_SOLS_ALIAS_B_BASE),
+                () -> verify(jsonObjectUtilsMock).findObjectInQuery(any(), any(), any(), any()),
+                () -> verify(forename).put(CaseMatchingJsonService.QUERY, alias)
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.casematching.Case;
 import uk.gov.hmcts.probate.model.ccd.raw.casematching.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.casematching.MatchedCases;
 import uk.gov.hmcts.probate.model.criterion.CaseMatchingCriteria;
+import uk.gov.hmcts.probate.query.CaseMatchingJson;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -47,7 +48,7 @@ class CaseMatchingServiceTest {
     private CaseMatchingCriteria caseMatchingCriteria;
     @Mock
     private Case caseMock;
-    CaseMatchingJsonService.CaseMatchingJson caseMatchingJsonMock;
+    CaseMatchingJson caseMatchingJsonMock;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.CaseType.CAVEAT;
@@ -117,13 +118,81 @@ class CaseMatchingServiceTest {
     }
 
     @Test
-    void findMatches() {
+    void findMatchesOld() {
         CaseMatch caseMatch = CaseMatch.builder()
                 .caseLink(CaseLink.builder().caseReference("1").build())
                 .fullName("names surname")
                 .dod("2000-01-01")
                 .postcode("SW12 0FA")
                 .build();
+
+        when(caseMatchBuilderService.buildCaseMatch(caseMock)).thenReturn(caseMatch);
+
+        List<CaseMatch> caseMatches = caseMatchingService.findMatches(GRANT_OF_REPRESENTATION, caseMatchingCriteria);
+
+        assertEquals(1, caseMatches.size());
+        assertEquals("1", caseMatches.get(0).getCaseLink().getCaseReference());
+        assertEquals("names surname", caseMatches.get(0).getFullName());
+        assertEquals("2000-01-01", caseMatches.get(0).getDod());
+        assertEquals("SW12 0FA", caseMatches.get(0).getPostcode());
+        assertNull(caseMatches.get(0).getValid());
+        assertNull(caseMatches.get(0).getComment());
+    }
+
+    @Test
+    void findMatchesNew() {
+        CaseMatch caseMatch = CaseMatch.builder()
+                .caseLink(CaseLink.builder().caseReference("1").build())
+                .fullName("names surname")
+                .dod("2000-01-01")
+                .postcode("SW12 0FA")
+                .build();
+
+        when(featureToggleServiceMock.useJsonLibForCaseMatching())
+                .thenReturn(true);
+
+        final CaseMatchingJson baseQueryMock = mock();
+        final CaseMatchingJson withForenamesMock = mock();
+        final CaseMatchingJson withSurnameMock = mock();
+        final CaseMatchingJson withFullNameMock = mock();
+
+        final Optional<CaseMatchingJson> birthMock = mock();
+        final CaseMatchingJson withDateOfBirthMock = mock();
+
+        final Optional<CaseMatchingJson> deathMock = mock();
+        final CaseMatchingJson withDateOfDeathMock = mock();
+
+        final List<CaseMatchingJson> aliasesMock = mock();
+        final CaseMatchingJson withAliasesMock = mock();
+
+        final JSONObject queryMock = mock();
+
+        when(caseMatchingJsonService.getBaseQuery())
+                .thenReturn(baseQueryMock);
+        when(caseMatchingJsonService.getDateOfBirthSubquery(any()))
+                .thenReturn(birthMock);
+        when(caseMatchingJsonService.getDateOfDeathSubquery(any()))
+                .thenReturn(deathMock);
+        when(caseMatchingJsonService.getAliasesSubqueries(any()))
+                .thenReturn(aliasesMock);
+
+        when(baseQueryMock.withDeceasedForenames(any()))
+                .thenReturn(withForenamesMock);
+        when(withForenamesMock.withDeceasedSurname(any()))
+                .thenReturn(withSurnameMock);
+        when(withSurnameMock.withDeceasedFullname(any()))
+                .thenReturn(withFullNameMock);
+        when(withFullNameMock.withDateOfBirth(birthMock))
+                .thenReturn(withDateOfBirthMock);
+        when(withDateOfBirthMock.withDateOfDeath(deathMock))
+                .thenReturn(withDateOfDeathMock);
+        when(withDateOfDeathMock.withAliases(aliasesMock))
+                .thenReturn(withAliasesMock);
+        when(withAliasesMock.stealJson())
+                .thenReturn(Optional.of(queryMock));
+
+        when(elasticSearchService.runJsonQuery(any(), eq(queryMock)))
+                .thenReturn(new MatchedCases(Collections.singletonList(caseMock)));
 
         when(caseMatchBuilderService.buildCaseMatch(caseMock)).thenReturn(caseMatch);
 

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.probate.service;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.probate.model.CaseType;
@@ -19,39 +19,76 @@ import uk.gov.hmcts.probate.model.criterion.CaseMatchingCriteria;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.probate.model.CaseType.CAVEAT;
 import static uk.gov.hmcts.probate.model.CaseType.GRANT_OF_REPRESENTATION;
 
 class CaseMatchingServiceTest {
 
-    @InjectMocks
     private CaseMatchingService caseMatchingService;
 
     @Mock
-    private ElasticSearchService elasticSearchService;
-
+    FileSystemResourceService fileSystemResourceService;
     @Mock
-    private CaseMatchBuilderService caseMatchBuilderService;
+    ElasticSearchService elasticSearchService;
+    @Mock
+    CaseMatchBuilderService caseMatchBuilderService;
+    @Mock
+    CaseMatchingJsonService caseMatchingJsonService;
 
     @Mock
     private CaseMatchingCriteria caseMatchingCriteria;
-
-    @Mock
-    private FileSystemResourceService fileSystemResourceService;
-
     @Mock
     private Case caseMock;
+    CaseMatchingJsonService.CaseMatchingJson caseMatchingJsonMock;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
+        caseMatchingService = new CaseMatchingService(
+                fileSystemResourceService,
+                elasticSearchService,
+                caseMatchBuilderService,
+                caseMatchingJsonService);
+
+        // common mock behaviours
+        when(elasticSearchService.runQuery(any(CaseType.class), anyString()))
+                .thenReturn(new MatchedCases(Collections.singletonList(caseMock)));
+
+        when(fileSystemResourceService.getFileFromResourceAsString(anyString()))
+                .thenReturn("template");
+
+        caseMatchingJsonMock = mock();
+        when(caseMatchingJsonService.getBaseQuery())
+                .thenReturn(caseMatchingJsonMock);
+
+        when(caseMatchingJsonMock.withDeceasedForenames(anyString()))
+                .thenReturn(caseMatchingJsonMock);
+        when(caseMatchingJsonMock.withDeceasedSurname(anyString()))
+                .thenReturn(caseMatchingJsonMock);
+        when(caseMatchingJsonMock.withDeceasedFullname(anyString()))
+                .thenReturn(caseMatchingJsonMock);
+        when(caseMatchingJsonMock.withDateOfBirth(any()))
+                .thenReturn(caseMatchingJsonMock);
+        when(caseMatchingJsonMock.withDateOfDeath(any()))
+                .thenReturn(caseMatchingJsonMock);
+        when(caseMatchingJsonMock.withAliases(any()))
+                .thenReturn(caseMatchingJsonMock);
+
+        when(caseMatchingJsonMock.stealJson())
+                .thenReturn(
+                        Optional.of(new JSONObject("{}")),
+                        Optional.empty());
+
+        // mocked input data behaviours
         CaseData caseData = CaseData.builder()
                 .deceasedForenames("names")
                 .deceasedSurname("surname")
@@ -69,11 +106,6 @@ class CaseMatchingServiceTest {
 
         when(caseMock.getData()).thenReturn(caseData);
         when(caseMock.getId()).thenReturn(1L);
-        when(elasticSearchService.runQuery(any(CaseType.class), anyString()))
-                .thenReturn(new MatchedCases(Collections.singletonList(caseMock)));
-
-        when(fileSystemResourceService.getFileFromResourceAsString(anyString()))
-                .thenReturn("template");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/CaseMatchingServiceTest.java
@@ -48,7 +48,10 @@ class CaseMatchingServiceTest {
     private CaseMatchingCriteria caseMatchingCriteria;
     @Mock
     private Case caseMock;
+    @Mock
     CaseMatchingJson caseMatchingJsonMock;
+    @Mock
+    FeatureToggleService featureToggleServiceMock;
 
     @BeforeEach
     public void setUp() {
@@ -58,7 +61,8 @@ class CaseMatchingServiceTest {
                 fileSystemResourceService,
                 elasticSearchService,
                 caseMatchBuilderService,
-                caseMatchingJsonService);
+                caseMatchingJsonService,
+                featureToggleServiceMock);
 
         // common mock behaviours
         when(elasticSearchService.runQuery(any(CaseType.class), anyString()))
@@ -88,6 +92,9 @@ class CaseMatchingServiceTest {
                 .thenReturn(
                         Optional.of(new JSONObject("{}")),
                         Optional.empty());
+
+        when(featureToggleServiceMock.useJsonLibForCaseMatching())
+                .thenReturn(false);
 
         // mocked input data behaviours
         CaseData caseData = CaseData.builder()

--- a/src/test/java/uk/gov/hmcts/probate/service/ElasticSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ElasticSearchServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.probate.service;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -22,7 +23,10 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,5 +75,20 @@ class ElasticSearchServiceTest {
 
             MatchedCases matchedCases = elasticSearchService.runQuery(CaseType.LEGACY, "{}");
         });
+    }
+
+    @Test
+    void runJsonQuery() {
+        final JSONObject jsonMock = mock();
+        when(jsonMock.toString(anyInt())).thenReturn("{}");
+
+        final MatchedCases matchedCases = elasticSearchService.runJsonQuery(
+                CaseType.LEGACY,
+                jsonMock);
+
+        assertEquals(1, matchedCases.getCases().size());
+
+        verify(restTemplate).postForObject(any(), any(), eq(MatchedCases.class));
+        verify(jsonMock).toString(anyInt());
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/ElasticSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/ElasticSearchServiceTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/hmcts/probate/service/JsonObjectUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/JsonObjectUtilsTest.java
@@ -1,0 +1,163 @@
+package uk.gov.hmcts.probate.service;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.probate.exception.JsonObjectUtilsException;
+import uk.gov.hmcts.probate.exception.JsonObjectUtilsException.Cause;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonObjectUtilsTest {
+
+    JsonObjectUtils jsonObjectUtils;
+
+    @BeforeEach
+    void setUp() {
+        this.jsonObjectUtils = new JsonObjectUtils();
+    }
+
+    @Test
+    void testFindObjectInQuerySucceeds() {
+        final String topKey = "value";
+        final String subKey = "present";
+        final String subKeyValue = "true";
+
+        final JSONObject subObject = new JSONObject()
+                .put(subKey, subKeyValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subObject);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JSONObject actual = jsonObjectUtils.findObjectInQuery(
+                toQuery,
+                pointer,
+                subKey,
+                subKeyValue);
+
+        assertThat(actual, sameInstance(subObject));
+    }
+
+    @Test
+    void testFindObjectInQueryThrowsIfSubValueMismatch() {
+        final String topKey = "value";
+        final String subKey = "present";
+        final String subKeyValue = "true";
+        final String incorrectSubKeyValue = "incorrect";
+
+        final JSONObject subObject = new JSONObject()
+                .put(subKey, subKeyValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subObject);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JsonObjectUtilsException ex = assertThrows(
+                JsonObjectUtilsException.class,
+                () -> jsonObjectUtils.findObjectInQuery(
+                        toQuery,
+                        pointer,
+                        subKey,
+                        incorrectSubKeyValue));
+
+        assertThat(ex.getErrorCause(), is(Cause.MISMATCHED_SUBKEY));
+    }
+
+    @Test
+    void testFindObjectInQueryThrowsIfSubKeyMismatch() {
+        final String topKey = "value";
+        final String subKey = "present";
+        final String incorrectSubKey = "missing";
+        final String subKeyValue = "true";
+
+        final JSONObject subObject = new JSONObject()
+                .put(subKey, subKeyValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subObject);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JsonObjectUtilsException ex = assertThrows(
+                JsonObjectUtilsException.class,
+                () -> jsonObjectUtils.findObjectInQuery(
+                        toQuery,
+                        pointer,
+                        incorrectSubKey,
+                        subKeyValue));
+
+        assertThat(ex.getErrorCause(), is(Cause.NO_SUBKEY));
+    }
+
+    @Test
+    void testFindObjectInQueryThrowsIfSubValueNotObject() {
+        final String topKey = "value";
+        final String subKey = "present";
+        final String subKeyValue = "true";
+
+        final JSONArray subArray = new JSONArray()
+                .put(subKey)
+                .put(subKeyValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subArray);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JsonObjectUtilsException ex = assertThrows(
+                JsonObjectUtilsException.class,
+                () -> jsonObjectUtils.findObjectInQuery(
+                        toQuery,
+                        pointer,
+                        subKey,
+                        subKeyValue));
+
+        assertThat(ex.getErrorCause(), is(Cause.WRONG_TYPE));
+    }
+
+    @Test
+    void testFindArrayInQuerySucceeds() {
+        final String topKey = "value";
+        final String subValue = "present";
+
+        final JSONArray subArray = new JSONArray()
+                .put(subValue)
+                .put(subValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subArray);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JSONArray actual = jsonObjectUtils.findArrayInQuery(
+                toQuery,
+                pointer);
+
+        assertThat(actual, sameInstance(subArray));
+    }
+
+    @Test
+    void testFindArrayInQueryThrowsIfSubValueNotArray() {
+        final String topKey = "value";
+        final String subKey = "present";
+        final String subKeyValue = "true";
+
+        final JSONObject subObject = new JSONObject()
+                .put(subKey, subKeyValue);
+
+        final JSONObject toQuery = new JSONObject()
+                .put(topKey, subObject);
+        final JSONPointer pointer = new JSONPointer("/" + topKey);
+
+        final JsonObjectUtilsException ex = assertThrows(
+                JsonObjectUtilsException.class,
+                () -> jsonObjectUtils.findArrayInQuery(
+                        toQuery,
+                        pointer));
+
+        assertThat(ex.getErrorCause(), is(Cause.WRONG_TYPE));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-5206](https://tools.hmcts.net/jira/browse/DTSPB-5206)


### Change description ###
Adds a new implementation (controlled by a feature toggle) which uses a JSON library based approach to constructing the JSON query for the case matching handling. This solves the issues we have seen where inputs have names have characters which cause the output generated by the existing handling to be malformed json and thus the queries to fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
