### PR TITLE
[DTSPB-4791] Add LaunchDarkly toggle for Smee & Ford email notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -23,7 +23,7 @@ public class FeatureToggleService {
     private static final String DECLARATION_NOT_SIGNED_TOGGLE = "probate-cron-declaration-not-signed";
     private static final String NFI_DATA_EXTRACT_TOGGLE = "probate-nfi-data-extract";
     private static final String SMEE_AND_FORD_COMMENT_FIELD_TOGGLE = "probate-smee-ford-comment-field";
-    private static final String SMEE_AND_FORD_EMAIL_TOGGLE = "probate-smee-ford-email";
+    private static final String DISABLE_SMEE_AND_FORD_EMAIL_TOGGLE = "probate-disable-smee-ford-email";
     private static final String USE_JSON_LIB_FOR_CASE_MATCHING = "probate-use-json-lib-for-case-matching";
     private static final String USE_PRIMARY_NOTIFY_KEY = "probate-use-primary-notify-key";
 
@@ -124,9 +124,9 @@ public class FeatureToggleService {
                 SMEE_AND_FORD_COMMENT_FIELD_TOGGLE, false);
     }
 
-    public boolean isSmeeAndFordEmailFeatureToggleOn() {
+    public boolean isProbateDisableSmeeAndFordEmailFeatureEnabled() {
         return this.isFeatureToggleOn(
-                SMEE_AND_FORD_EMAIL_TOGGLE, false);
+                DISABLE_SMEE_AND_FORD_EMAIL_TOGGLE, false);
     }
 
     public boolean useJsonLibForCaseMatching() {

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -23,6 +23,7 @@ public class FeatureToggleService {
     private static final String DECLARATION_NOT_SIGNED_TOGGLE = "probate-cron-declaration-not-signed";
     private static final String NFI_DATA_EXTRACT_TOGGLE = "probate-nfi-data-extract";
     private static final String SMEE_AND_FORD_COMMENT_FIELD_TOGGLE = "probate-smee-ford-comment-field";
+    private static final String SMEE_AND_FORD_EMAIL_TOGGLE = "probate-smee-ford-email";
     private static final String USE_JSON_LIB_FOR_CASE_MATCHING = "probate-use-json-lib-for-case-matching";
     private static final String USE_PRIMARY_NOTIFY_KEY = "probate-use-primary-notify-key";
 
@@ -121,6 +122,11 @@ public class FeatureToggleService {
     public boolean isSmeeAndFordCommentFieldFeatureToggleOn() {
         return this.isFeatureToggleOn(
                 SMEE_AND_FORD_COMMENT_FIELD_TOGGLE, false);
+    }
+
+    public boolean isSmeeAndFordEmailFeatureToggleOn() {
+        return this.isFeatureToggleOn(
+                SMEE_AND_FORD_EMAIL_TOGGLE, false);
     }
 
     public boolean useJsonLibForCaseMatching() {

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -23,7 +23,7 @@ public class FeatureToggleService {
     private static final String DECLARATION_NOT_SIGNED_TOGGLE = "probate-cron-declaration-not-signed";
     private static final String NFI_DATA_EXTRACT_TOGGLE = "probate-nfi-data-extract";
     private static final String SMEE_AND_FORD_COMMENT_FIELD_TOGGLE = "probate-smee-ford-comment-field";
-    private static final String DISABLE_SMEE_AND_FORD_EMAIL_TOGGLE = "probate-disable-smee-ford-email";
+    private static final String DISABLE_SMEE_AND_FORD_EMAIL_NOTIFICATION_TOGGLE = "probate-disable-smee-ford-email";
     private static final String USE_JSON_LIB_FOR_CASE_MATCHING = "probate-use-json-lib-for-case-matching";
     private static final String USE_PRIMARY_NOTIFY_KEY = "probate-use-primary-notify-key";
 
@@ -124,9 +124,9 @@ public class FeatureToggleService {
                 SMEE_AND_FORD_COMMENT_FIELD_TOGGLE, false);
     }
 
-    public boolean isProbateDisableSmeeAndFordEmailFeatureEnabled() {
+    public boolean isSmeeAndFordEmailNotificationDisabled() {
         return this.isFeatureToggleOn(
-                DISABLE_SMEE_AND_FORD_EMAIL_TOGGLE, false);
+                DISABLE_SMEE_AND_FORD_EMAIL_NOTIFICATION_TOGGLE, false);
     }
 
     public boolean useJsonLibForCaseMatching() {

--- a/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
@@ -68,10 +68,15 @@ public class SmeeAndFordDataExtractService {
                     log.info("Zip file uploaded on blob store");
                     Files.deleteIfExists(tempFile.toPath());
                 }
-                boolean isSmeeAndFordEmailDisabled = featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled();
-                log.info("LaunchDarkly flag probate-disable-smee-ford-email is enabled: {}", isSmeeAndFordEmailDisabled);
+                boolean isSmeeAndFordEmailDisabled =
+                    featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled();
+                log.info(
+                    "LaunchDarkly flag probate-disable-smee-ford-email is enabled: {}",
+                    isSmeeAndFordEmailDisabled
+                );
                 if (isSmeeAndFordEmailDisabled) {
-                    log.info("Skipping Smee & Ford email notification because probate-disable-smee-ford-email flag in LaunchDarkly feature is true.");
+                    log.info("Skipping Smee & Ford email notification because "
+                        + "probate-disable-smee-ford-email flag in LaunchDarkly feature is true.");
                 } else {
                     notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
 

--- a/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
@@ -68,13 +68,13 @@ public class SmeeAndFordDataExtractService {
                     log.info("Zip file uploaded on blob store");
                     Files.deleteIfExists(tempFile.toPath());
                 }
-                boolean isSmeeAndFordEmailDisabled =
-                    featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled();
+                boolean isSmeeAndFordEmailNotificationDisabled =
+                    featureToggleService.isSmeeAndFordEmailNotificationDisabled();
                 log.info(
                     "LaunchDarkly flag probate-disable-smee-ford-email is enabled: {}",
-                    isSmeeAndFordEmailDisabled
+                    isSmeeAndFordEmailNotificationDisabled
                 );
-                if (isSmeeAndFordEmailDisabled) {
+                if (isSmeeAndFordEmailNotificationDisabled) {
                     log.info("Skipping Smee & Ford email notification because "
                         + "probate-disable-smee-ford-email flag in LaunchDarkly feature is true.");
                 } else {

--- a/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
@@ -68,13 +68,16 @@ public class SmeeAndFordDataExtractService {
                     log.info("Zip file uploaded on blob store");
                     Files.deleteIfExists(tempFile.toPath());
                 }
-                boolean isSmeeAndFordEmailEnabled = featureToggleService.isSmeeAndFordEmailFeatureToggleOn();
-                log.info("Smee & Ford email LaunchDarkly feature enabled is {}", isSmeeAndFordEmailEnabled);
-                if (isSmeeAndFordEmailEnabled) {
-                    notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
+                boolean isSmeeAndFordEmailDisabled = featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled();
+                log.info("LaunchDarkly flag probate-disable-smee-ford-email is enabled: {}", isSmeeAndFordEmailDisabled);
+                if (isSmeeAndFordEmailDisabled) {
+                    log.info("Skipping Smee & Ford email notification because probate-disable-smee-ford-email flag in LaunchDarkly feature is true.");
                 } else {
-                    log.info("Skipping Smee & Ford email notification because LaunchDarkly feature disabled.");
+                    notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
+
                 }
+
+
             } catch (NotificationClientException e) {
                 log.warn("NotificationService exception sending email to Smee And Ford", e);
                 throw new ClientException(HttpStatus.BAD_GATEWAY.value(),

--- a/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.probate.exception.ClientException;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.model.zip.SmeeAndFordCommentMode;
 import uk.gov.hmcts.probate.service.CaseQueryService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.NotificationService;
 import uk.gov.hmcts.probate.service.zip.ZipFileService;
 import uk.gov.service.notify.NotificationClientException;
@@ -28,11 +29,9 @@ public class SmeeAndFordDataExtractService {
     private final NotificationService notificationService;
     private final ZipFileService zipFileService;
     private final SmeeAndFordDataExtractStrategy smeeAndFordDataExtractStrategy;
+    private final FeatureToggleService featureToggleService;
     @Value("${feature.blobstorage.smeeandford.enabled}")
     public boolean featureBlobStorageSmeeAndFord;
-
-    @Value("${feature.smeeandford.email.enabled:false}")
-    public boolean featureSmeeAndFordEmailEnabled;
 
     public void performSmeeAndFordExtractForDateRange(String fromDate, String toDate) {
         if (fromDate.equals(toDate)) {
@@ -69,11 +68,12 @@ public class SmeeAndFordDataExtractService {
                     log.info("Zip file uploaded on blob store");
                     Files.deleteIfExists(tempFile.toPath());
                 }
-                if (featureSmeeAndFordEmailEnabled) {
-                    log.info("Smee & Ford email feature enabled, sending notification email.");
+                boolean isSmeeAndFordEmailEnabled = featureToggleService.isSmeeAndFordEmailFeatureToggleOn();
+                log.info("Smee & Ford email LaunchDarkly feature enabled is {}", isSmeeAndFordEmailEnabled);
+                if (isSmeeAndFordEmailEnabled) {
                     notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
                 } else {
-                    log.info("Smee & Ford email feature disabled, not sending notification email.");
+                    log.info("Skipping Smee & Ford email notification because LaunchDarkly feature disabled.");
                 }
             } catch (NotificationClientException e) {
                 log.warn("NotificationService exception sending email to Smee And Ford", e);

--- a/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractService.java
@@ -31,6 +31,9 @@ public class SmeeAndFordDataExtractService {
     @Value("${feature.blobstorage.smeeandford.enabled}")
     public boolean featureBlobStorageSmeeAndFord;
 
+    @Value("${feature.smeeandford.email.enabled:false}")
+    public boolean featureSmeeAndFordEmailEnabled;
+
     public void performSmeeAndFordExtractForDateRange(String fromDate, String toDate) {
         if (fromDate.equals(toDate)) {
             performSmeeAndFordExtractForDate(fromDate);
@@ -66,7 +69,12 @@ public class SmeeAndFordDataExtractService {
                     log.info("Zip file uploaded on blob store");
                     Files.deleteIfExists(tempFile.toPath());
                 }
-                notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
+                if (featureSmeeAndFordEmailEnabled) {
+                    log.info("Smee & Ford email feature enabled, sending notification email.");
+                    notificationService.sendSmeeAndFordEmail(cases, fromDate, toDate);
+                } else {
+                    log.info("Smee & Ford email feature disabled, not sending notification email.");
+                }
             } catch (NotificationClientException e) {
                 log.warn("NotificationService exception sending email to Smee And Ford", e);
                 throw new ClientException(HttpStatus.BAD_GATEWAY.value(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -756,9 +756,6 @@ feature:
   blobstorage:
     smeeandford:
       enabled: ${BLOB_STORAGE_SMEEANDFORD_FEATURE_ENABLED:true}
-  smeeandford:
-    email:
-      enabled: ${SMEEANDFORD_EMAIL_FEATURE_ENABLED:true}
 
 ld:
   sdk_key: ${LAUNCHDARKLY_KEY:dummy}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -756,6 +756,9 @@ feature:
   blobstorage:
     smeeandford:
       enabled: ${BLOB_STORAGE_SMEEANDFORD_FEATURE_ENABLED:true}
+  smeeandford:
+    email:
+      enabled: ${SMEEANDFORD_EMAIL_FEATURE_ENABLED:true}
 
 ld:
   sdk_key: ${LAUNCHDARKLY_KEY:dummy}

--- a/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
@@ -27,14 +27,14 @@ class FeatureToggleServiceTest {
     }
 
     @Test
-    void shouldUseSmeeAndFordEmailLaunchDarklyFlagWithFalseDefault() {
+    void shouldUseSmeeAndFordEmailNotificationDisabledFlagWithFalseDefault() {
         when(ldClient.boolVariation(
             eq("probate-disable-smee-ford-email"),
             any(LDContext.class),
             eq(false)
         )).thenReturn(true);
 
-        assertTrue(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled());
+        assertTrue(featureToggleService.isSmeeAndFordEmailNotificationDisabled());
 
         verify(ldClient).boolVariation(eq("probate-disable-smee-ford-email"), any(LDContext.class), eq(false));
     }

--- a/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
@@ -28,10 +28,10 @@ class FeatureToggleServiceTest {
 
     @Test
     void shouldUseSmeeAndFordEmailLaunchDarklyFlagWithFalseDefault() {
-        when(ldClient.boolVariation(eq("probate-smee-ford-email"), any(LDContext.class), eq(false))).thenReturn(true);
+        when(ldClient.boolVariation(eq("probate-disable-smee-ford-email"), any(LDContext.class), eq(false))).thenReturn(true);
 
-        assertTrue(featureToggleService.isSmeeAndFordEmailFeatureToggleOn());
+        assertTrue(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled());
 
-        verify(ldClient).boolVariation(eq("probate-smee-ford-email"), any(LDContext.class), eq(false));
+        verify(ldClient).boolVariation(eq("probate-disable-smee-ford-email"), any(LDContext.class), eq(false));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.probate.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureToggleServiceTest {
+    @Mock
+    private LDClient ldClient;
+
+    private FeatureToggleService featureToggleService;
+
+    @BeforeEach
+    void setUp() {
+        featureToggleService = new FeatureToggleService(ldClient, "probate", "Probate", "Backend");
+    }
+
+    @Test
+    void shouldUseSmeeAndFordEmailLaunchDarklyFlagWithFalseDefault() {
+        when(ldClient.boolVariation(eq("probate-smee-ford-email"), any(LDContext.class), eq(false))).thenReturn(true);
+
+        assertTrue(featureToggleService.isSmeeAndFordEmailFeatureToggleOn());
+
+        verify(ldClient).boolVariation(eq("probate-smee-ford-email"), any(LDContext.class), eq(false));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/FeatureToggleServiceTest.java
@@ -28,7 +28,11 @@ class FeatureToggleServiceTest {
 
     @Test
     void shouldUseSmeeAndFordEmailLaunchDarklyFlagWithFalseDefault() {
-        when(ldClient.boolVariation(eq("probate-disable-smee-ford-email"), any(LDContext.class), eq(false))).thenReturn(true);
+        when(ldClient.boolVariation(
+            eq("probate-disable-smee-ford-email"),
+            any(LDContext.class),
+            eq(false)
+        )).thenReturn(true);
 
         assertTrue(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled());
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -107,20 +107,20 @@ class SmeeAndFordDataExtractServiceTest {
 
     @Test
     void shouldExtractForDate() throws NotificationClientException {
-        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
+        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
-        verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
+        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
     void shouldExtractForDateRange() throws NotificationClientException {
-        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
+        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
-        verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
+        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
@@ -131,7 +131,7 @@ class SmeeAndFordDataExtractServiceTest {
             ".zip"
         );
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
-        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
+        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
         when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
@@ -144,7 +144,7 @@ class SmeeAndFordDataExtractServiceTest {
             eq(smeeAndFOrdDataExtractStrategy),
             any()
         );
-        verify(notificationService, never()).sendSmeeAndFordEmail(
+        verify(notificationService, times(1)).sendSmeeAndFordEmail(
             any(),
             any(),
             any()
@@ -152,10 +152,38 @@ class SmeeAndFordDataExtractServiceTest {
     }
 
     @Test
-    void shouldSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
-        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(true);
+    void shouldExtractDataForDateRangeAndGenerateZipFileAndUploadWhenEmailEnabled()
+            throws NotificationClientException, IOException {
+        File tempFile = File.createTempFile(
+                "Probate_Docs_2000-12-30",
+                ".zip"
+        );
+        smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
+        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(true);
+        when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
+
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
-        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), any(), any());
+
+        verify(zipFileService, times(1)).createTempZipFile("Probate_Docs_2000-12-30");
+        verify(zipFileService, times(1)).generateAndUploadZipFile(
+                any(),
+                eq(tempFile),
+                eq("2000-12-30"),
+                eq(smeeAndFOrdDataExtractStrategy),
+                any()
+        );
+        verify(notificationService, never()).sendSmeeAndFordEmail(
+                any(),
+                any(),
+                any()
+        );
+    }
+
+    @Test
+    void shouldNotSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
+        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(true);
+        smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
@@ -174,7 +202,7 @@ class SmeeAndFordDataExtractServiceTest {
     @Test
     void shouldThrowClientExceptionForDateRange() {
         assertThrows(ClientException.class, () -> {
-            when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(true);
+            when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -107,7 +107,7 @@ class SmeeAndFordDataExtractServiceTest {
 
     @Test
     void shouldExtractForDate() throws NotificationClientException {
-        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
+        when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(false);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
@@ -116,7 +116,7 @@ class SmeeAndFordDataExtractServiceTest {
 
     @Test
     void shouldExtractForDateRange() throws NotificationClientException {
-        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
+        when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(false);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
@@ -131,7 +131,7 @@ class SmeeAndFordDataExtractServiceTest {
             ".zip"
         );
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
-        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
+        when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(false);
         when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
@@ -159,7 +159,7 @@ class SmeeAndFordDataExtractServiceTest {
                 ".zip"
         );
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
-        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(true);
+        when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(true);
         when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
@@ -181,7 +181,7 @@ class SmeeAndFordDataExtractServiceTest {
 
     @Test
     void shouldNotSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
-        when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(true);
+        when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(true);
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
         verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
     }
@@ -202,7 +202,7 @@ class SmeeAndFordDataExtractServiceTest {
     @Test
     void shouldThrowClientExceptionForDateRange() {
         assertThrows(ClientException.class, () -> {
-            when(featureToggleService.isProbateDisableSmeeAndFordEmailFeatureEnabled()).thenReturn(false);
+            when(featureToggleService.isSmeeAndFordEmailNotificationDisabled()).thenReturn(false);
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.probate.service.NotificationService;
 import uk.gov.hmcts.probate.service.zip.ZipFileService;
 import uk.gov.service.notify.NotificationClientException;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -60,6 +61,7 @@ class SmeeAndFordDataExtractServiceTest {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = false;
+        smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = false;
         CollectionMember<ScannedDocument> scannedDocument = new CollectionMember<>(new ScannedDocument("1",
             "test", "other", "will", LocalDateTime.now(), DocumentLink.builder().build(),
             "test", LocalDateTime.now()));
@@ -92,14 +94,36 @@ class SmeeAndFordDataExtractServiceTest {
     void shouldExtractForDate() throws NotificationClientException {
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
-        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
+        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
     }
 
     @Test
     void shouldExtractForDateRange() throws NotificationClientException {
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
+        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+    }
+
+    @Test
+    void shouldExtractDataForDateRangeAndGenerateZipFileAndUploadWhenEmailDisabled() throws NotificationClientException, IOException {
+        File tempFile = File.createTempFile("Probate_Docs_2000-12-30", ".zip");
+        smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
+        when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
+
+        smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
+
+        verify(zipFileService, times(1)).createTempZipFile("Probate_Docs_2000-12-30");
+        verify(zipFileService, times(1)).generateAndUploadZipFile(any(), eq(tempFile), eq("2000-12-30"),eq(smeeAndFOrdDataExtractStrategy), any());
+        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+
+    }
+
+    @Test
+    void shouldSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
+        smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = true;
+        smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
         verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+
     }
 
     @Test
@@ -118,6 +142,7 @@ class SmeeAndFordDataExtractServiceTest {
     @Test
     void shouldThrowClientExceptionForDateRange() {
         assertThrows(ClientException.class, () -> {
+            smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = true;
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -31,7 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 class SmeeAndFordDataExtractServiceTest {
 
@@ -107,7 +111,7 @@ class SmeeAndFordDataExtractServiceTest {
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
-        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
@@ -116,7 +120,7 @@ class SmeeAndFordDataExtractServiceTest {
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
-        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
@@ -142,8 +146,8 @@ class SmeeAndFordDataExtractServiceTest {
         );
         verify(notificationService, never()).sendSmeeAndFordEmail(
             any(),
-            eq("2000-12-30"),
-            eq("2000-12-31")
+            any(),
+            any()
         );
     }
 
@@ -151,7 +155,7 @@ class SmeeAndFordDataExtractServiceTest {
     void shouldSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
         when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(true);
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
-        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+        verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), any(), any());
     }
 
     @Test
@@ -174,7 +178,7 @@ class SmeeAndFordDataExtractServiceTest {
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 
-            smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
+            smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange(any(), any());
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -206,7 +206,7 @@ class SmeeAndFordDataExtractServiceTest {
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 
-            smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange(any(), any());
+            smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
         });
     }
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.probate.model.ccd.raw.ScannedDocument;
 import uk.gov.hmcts.probate.model.ccd.raw.request.CaseData;
 import uk.gov.hmcts.probate.model.ccd.raw.request.ReturnedCaseDetails;
 import uk.gov.hmcts.probate.service.CaseQueryService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 import uk.gov.hmcts.probate.service.NotificationService;
 import uk.gov.hmcts.probate.service.zip.ZipFileService;
 import uk.gov.service.notify.NotificationClientException;
@@ -22,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,22 +49,30 @@ class SmeeAndFordDataExtractServiceTest {
     private BlobUpload blobUpload;
     @Mock
     private SmeeAndFordDataExtractStrategy smeeAndFOrdDataExtractStrategy;
+    @Mock
+    private FeatureToggleService featureToggleService;
 
     private static final LocalDateTime LAST_MODIFIED = LocalDateTime.now(ZoneOffset.UTC).minusYears(2);
 
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    private CaseData caseData1;
-    private CaseData caseData2;
-    private List<ReturnedCaseDetails> returnedCases;
+    // ...existing code...
 
+    private AutoCloseable mocks;
     @BeforeEach
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
+    public void setup() throws Exception {
+        mocks = MockitoAnnotations.openMocks(this);
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = false;
-        smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = false;
-        CollectionMember<ScannedDocument> scannedDocument = new CollectionMember<>(new ScannedDocument("1",
-            "test", "other", "will", LocalDateTime.now(), DocumentLink.builder().build(),
-            "test", LocalDateTime.now()));
+        CollectionMember<ScannedDocument> scannedDocument = new CollectionMember<>(
+            new ScannedDocument(
+                "1",
+                "test",
+                "other",
+                "will",
+                LocalDateTime.now(),
+                DocumentLink.builder().build(),
+                "test",
+                LocalDateTime.now()
+            )
+        );
         CollectionMember<ScannedDocument> scannedDocumentNullSubType = new CollectionMember<>(new ScannedDocument("1",
             "test", "other", null, LocalDateTime.now(), DocumentLink.builder().build(),
             "test", LocalDateTime.now()));
@@ -72,11 +80,11 @@ class SmeeAndFordDataExtractServiceTest {
         scannedDocuments.add(scannedDocument);
         scannedDocuments.add(scannedDocumentNullSubType);
 
-        caseData1 = CaseData.builder()
+        CaseData caseData1 = CaseData.builder()
             .deceasedSurname("smith")
             .scannedDocuments(scannedDocuments)
             .build();
-        caseData2 = CaseData.builder()
+        CaseData caseData2 = CaseData.builder()
             .deceasedSurname("jones")
             .scannedDocuments(scannedDocuments)
             .build();
@@ -85,13 +93,21 @@ class SmeeAndFordDataExtractServiceTest {
             .add(new ReturnedCaseDetails(caseData2, LAST_MODIFIED, 2L))
             .build();
 
-
         when(caseQueryService.findAllCasesWithGrantIssuedDate(any(), any())).thenReturn(returnedCases);
         when(caseQueryService.findCaseStateWithinDateRangeSmeeAndFord(any(), any())).thenReturn(returnedCases);
     }
 
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
     @Test
     void shouldExtractForDate() throws NotificationClientException {
+        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
+
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
         verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
@@ -99,31 +115,46 @@ class SmeeAndFordDataExtractServiceTest {
 
     @Test
     void shouldExtractForDateRange() throws NotificationClientException {
+        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
+
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
         verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
     }
 
     @Test
-    void shouldExtractDataForDateRangeAndGenerateZipFileAndUploadWhenEmailDisabled() throws NotificationClientException, IOException {
-        File tempFile = File.createTempFile("Probate_Docs_2000-12-30", ".zip");
+    void shouldExtractDataForDateRangeAndGenerateZipFileAndUploadWhenEmailDisabled()
+        throws NotificationClientException, IOException {
+        File tempFile = File.createTempFile(
+            "Probate_Docs_2000-12-30",
+            ".zip"
+        );
         smeeAndFordDataExtractService.featureBlobStorageSmeeAndFord = true;
+        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(false);
         when(zipFileService.createTempZipFile("Probate_Docs_2000-12-30")).thenReturn(tempFile);
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
         verify(zipFileService, times(1)).createTempZipFile("Probate_Docs_2000-12-30");
-        verify(zipFileService, times(1)).generateAndUploadZipFile(any(), eq(tempFile), eq("2000-12-30"),eq(smeeAndFOrdDataExtractStrategy), any());
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
-
+        verify(zipFileService, times(1)).generateAndUploadZipFile(
+            any(),
+            eq(tempFile),
+            eq("2000-12-30"),
+            eq(smeeAndFOrdDataExtractStrategy),
+            any()
+        );
+        verify(notificationService, times(0)).sendSmeeAndFordEmail(
+            any(),
+            eq("2000-12-30"),
+            eq("2000-12-31")
+        );
     }
 
     @Test
     void shouldSendSmeeAndFordEmailWhenEmailFeatureEnabled() throws NotificationClientException {
-        smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = true;
+        when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(true);
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
         verify(notificationService, times(1)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
-
     }
 
     @Test
@@ -142,7 +173,7 @@ class SmeeAndFordDataExtractServiceTest {
     @Test
     void shouldThrowClientExceptionForDateRange() {
         assertThrows(ClientException.class, () -> {
-            smeeAndFordDataExtractService.featureSmeeAndFordEmailEnabled = true;
+            when(featureToggleService.isSmeeAndFordEmailFeatureToggleOn()).thenReturn(true);
             when(notificationService.sendSmeeAndFordEmail(any(), any(), any()))
                     .thenThrow(NotificationClientException.class);
 

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -54,9 +54,8 @@ class SmeeAndFordDataExtractServiceTest {
 
     private static final LocalDateTime LAST_MODIFIED = LocalDateTime.now(ZoneOffset.UTC).minusYears(2);
 
-    // ...existing code...
-
     private AutoCloseable mocks;
+
     @BeforeEach
     public void setup() throws Exception {
         mocks = MockitoAnnotations.openMocks(this);

--- a/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/service/dataextract/SmeeAndFordDataExtractServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.probate.service.dataextract;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -30,10 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class SmeeAndFordDataExtractServiceTest {
 
@@ -96,7 +94,7 @@ class SmeeAndFordDataExtractServiceTest {
         when(caseQueryService.findCaseStateWithinDateRangeSmeeAndFord(any(), any())).thenReturn(returnedCases);
     }
 
-    @org.junit.jupiter.api.AfterEach
+    @AfterEach
     public void tearDown() throws Exception {
         if (mocks != null) {
             mocks.close();
@@ -109,7 +107,7 @@ class SmeeAndFordDataExtractServiceTest {
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
     }
 
     @Test
@@ -118,7 +116,7 @@ class SmeeAndFordDataExtractServiceTest {
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-31");
 
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
     }
 
     @Test
@@ -142,7 +140,7 @@ class SmeeAndFordDataExtractServiceTest {
             eq(smeeAndFOrdDataExtractStrategy),
             any()
         );
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(
+        verify(notificationService, never()).sendSmeeAndFordEmail(
             any(),
             eq("2000-12-30"),
             eq("2000-12-31")
@@ -166,7 +164,7 @@ class SmeeAndFordDataExtractServiceTest {
 
         smeeAndFordDataExtractService.performSmeeAndFordExtractForDateRange("2000-12-30", "2000-12-30");
 
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-30"));
     }
 
     @Test
@@ -192,6 +190,6 @@ class SmeeAndFordDataExtractServiceTest {
         verify(zipFileService, times(0))
                 .generateAndUploadZipFile(any(), any(), any(), any(), any());
         verify(blobUpload, times(0)).uploadFile(any(), anyString(), anyString());
-        verify(notificationService, times(0)).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
+        verify(notificationService, never()).sendSmeeAndFordEmail(any(), eq("2000-12-30"), eq("2000-12-31"));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable)
See [DTSPB-4791](https://tools.hmcts.net/jira/browse/DTSPB-4791)

### Change description
Refactor Smee & Ford data extract workflow to include a LaunchDarkly-controlled "opt-out" toggle for email notifications and improved integration with Azure Blob Storage.

This PR:
- Implements the LaunchDarkly feature toggle `probate-disable-smee-ford-email` to suppress email notifications when enabled.
- Integrates with the `feature.blobstorage.smeeandford.enabled` configuration to control ZIP generation and Azure Blob Storage uploads.
- Decoupled ZIP/Blob storage operations from email delivery, ensuring data is persisted to the blob store regardless of whether the email notification is skipped.
- Updates service orchestration in `SmeeAndFordDataExtractService` to handle conditional execution paths.

This change is **functional**, providing safe configuration-driven control over external service invocations.

### Testing done
- **Unit Testing**: Validated `FeatureToggleService` for correct flag naming and default behavior.
- **Functional Testing**: Updated `SmeeAndFordDataExtractServiceTest` to verify that ZIP generation/upload and email delivery behave correctly under both `true` and `false` toggle states.
- Verified that ZIP files are deleted from temporary storage after successful upload to Azure.
- All tests pass locally and in the build pipeline.

### Impact
Low-risk behavioral change. The Smee & Ford extract process remains robust as ZIP generation/upload logic is maintained independently of the email notification status.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
- [ ] Yes
- [x] No

### Pre‑PR checks (must be satisfied)
- [x] Commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation have been updated or added where needed
- [x] Tests have been updated or new tests added where appropriate
- [x] CSS version has been updated to force cache refresh if styling changes were introduced

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

### Suggested labels
backend, feature-toggle, enhancement