### PR TITLE
disable syncBranchesWithMaster

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -214,7 +214,7 @@ withPipeline("java", product, component) {
 
   enableSlackNotifications('#probate-jenkins')
   enableHighLevelDataSetup()
-  syncBranchesWithMaster(branchesToSync)
+  //syncBranchesWithMaster(branchesToSync)
 
   afterAlways('test') {
     junit 'build/test-results/test/**/*.xml'


### PR DESCRIPTION
### Change description ###
disable syncBranchesWithMaster to avoid overwriting CCD definition in perftest (demo and ithc were disabled previously)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
