### PR TITLE
DTSPB-5808 bump httpcore5 and httpcore5-h2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,11 @@ dependencyManagement {
 
   dependencies {
     dependency group: 'org.camunda.connect', name: 'camunda-connect-connectors-all', version: versions.camunda
+
+    dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
+        entry 'httpcore5'
+        entry 'httpcore5-h2'
+    }
   }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -86,4 +86,11 @@
    ]]></notes>
         <cve>CVE-2026-53914</cve>
     </suppress>
+    <suppress until = "2026-10-13">
+        <notes><![CDATA[
+   file name: httpcore-4.4.16.jar
+   ]]></notes>
+        <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPB-5808


### Change description ###
bump httpcore5 and httpcore5-h2
suppress transitive CVE for httpcore-4.4.16

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
