### PR TITLE
suppress tomcat CVE-2026-66299

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '3.5.16'
   id 'uk.gov.hmcts.java' version '0.12.70'
-  id 'com.github.ben-manes.versions' version '0.59.0'
+  id 'io.github.ben-manes.versions' version '0.59.0'
   id 'com.gorylenko.gradle-git-properties' version '4.0.1'
   id 'info.solidsoft.pitest' version '1.19.0'
   id 'jacoco'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -55,4 +55,11 @@
         <cve>CVE-2026-44891</cve>
         <cve>CVE-2026-55831</cve>
     </suppress>
+    <suppress until = "2026-10-24">
+    <notes><![CDATA[
+   file name: tomcat-embed-core-10.1.57.jar
+   file name: tomcat-embed-websocket-10.1.57.jar
+   ]]></notes>
+        <cve>CVE-2026-66299</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
suppress tomcat CVE-2026-66299, as the patched version not yet released


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
