### PR TITLE
update subscription logic for non-prod environments in Jenkinsfile_CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -343,7 +343,7 @@ withPipeline("java", product, component) {
     if (env.ENV != 'preview') {
       // For Preview the setup is performed before the smoke test since the environment could be not bootstrapped yet (if the first build or removed the PR helm release)
       echo "CCD definition upload for environment: ${env.ENV}"
-      withSubscription(env.ENV != 'prod' ? 'nonprod' : 'prod') {
+      withSubscription(env.ENV in ['ithc', 'perftest'] ? 'qa' : env.ENV == 'prod' ? 'prod' : 'nonprod') {
         withTeamSecrets(pipelineConf, env.ENV) {
           archiveCoreCaseDataDefinitions(env.ENV, env.BRANCH_NAME)
           uploadCoreCaseDataDefinitions(env.ENV)


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-33854](https://tools.hmcts.net/jira/browse/DTSPO-33854)


### Change description ###
update subscription logic for non-prod environments in Jenkinsfile_CNP


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
